### PR TITLE
feat(headless): Omni model support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,6 +4247,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "audiopus 0.3.0-rc.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ uuid = { version = "1", features = ["v4"] }
 percent-encoding = "2"
 audiopus = "0.3.0-rc.0"
 md5 = "0.7"
+base64 = "0.22"
 prost = "0.12"
 prost-types = "0.12"
 tonic = "0.11"

--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -54,6 +54,7 @@ api_key = ""
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
 stream_output = false  # 流式输出：false 或 true（TTS快速响应)
+omni_model = false    # 全模态模型：true 时自动禁用 TTS/STT，直接使用语音输入输出
 
 # 限流配置
 [rate_limit]

--- a/src/adapter/headless/service.rs
+++ b/src/adapter/headless/service.rs
@@ -116,7 +116,11 @@ async fn stream_tts_audio_loop(
     mut stream: tonic::Streaming<voicev1::TtsAudioChunk>,
     ts3_audio_tx: mpsc::Sender<OutPacket>,
 ) -> anyhow::Result<()> {
-    let first_chunk = match stream.message().await.context("recv first tts chunk failed")? {
+    let first_chunk = match stream
+        .message()
+        .await
+        .context("recv first tts chunk failed")?
+    {
         Some(chunk) => chunk,
         None => return Ok(()),
     };
@@ -126,10 +130,7 @@ async fn stream_tts_audio_loop(
     } else if first_chunk.codec.eq_ignore_ascii_case("mp3") || first_chunk.codec.is_empty() {
         detect_audio_format(&first_chunk.payload)
     } else {
-        return Err(anyhow!(
-            "unsupported tts codec: {}",
-            first_chunk.codec
-        ));
+        return Err(anyhow!("unsupported tts codec: {}", first_chunk.codec));
     };
 
     let child = tokio::process::Command::new("ffmpeg")
@@ -578,8 +579,7 @@ impl VoiceService for VoiceServiceImpl {
             "",
         );
 
-        let result =
-            stream_tts_audio_loop(req.into_inner(), self.ts3_audio_tx.clone()).await;
+        let result = stream_tts_audio_loop(req.into_inner(), self.ts3_audio_tx.clone()).await;
 
         match result {
             Ok(()) => {

--- a/src/adapter/headless/speech.rs
+++ b/src/adapter/headless/speech.rs
@@ -284,7 +284,10 @@ impl OpenAiSpeechProvider {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            error!("tts unavailable: request failed with status {}: {}", status, err);
+            error!(
+                "tts unavailable: request failed with status {}: {}",
+                status, err
+            );
             return Err(anyhow!("tts request failed: status {} - {}", status, err));
         }
 
@@ -483,7 +486,10 @@ fn normalize_text(raw: &str) -> String {
 }
 
 fn skip_punct_and_whitespace(input: &str) -> &str {
-    let cjk_punct = ['，', '。', '！', '？', '；', '：', '、', '—', '…', '（', '）', '【', '】', '《', '》', '“', '”', '‘', '’'];
+    let cjk_punct = [
+        '，', '。', '！', '？', '；', '：', '、', '—', '…', '（', '）', '【', '】', '《', '》',
+        '“', '”', '‘', '’',
+    ];
     input.trim_start_matches(|c: char| {
         c.is_whitespace() || c.is_ascii_punctuation() || cjk_punct.contains(&c)
     })

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -7,6 +7,9 @@ pub struct LlmConfig {
     pub model: String,
     #[serde(default)]
     pub stream_output: bool,
+    /// Enable omni-modal model support (voice input/output directly)
+    #[serde(default)]
+    pub omni_model: bool,
 }
 
 impl Default for LlmConfig {
@@ -16,6 +19,7 @@ impl Default for LlmConfig {
             base_url: "https://api.openai.com/v1".to_string(),
             model: "gpt-4o".to_string(),
             stream_output: false,
+            omni_model: false,
         }
     }
 }

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -214,7 +214,8 @@ impl LlmProvider for OpenAiProvider {
                                 .await;
                         }
                     }
-                    if let Some(tool_calls) = event["choices"][0]["delta"]["tool_calls"].as_array() {
+                    if let Some(tool_calls) = event["choices"][0]["delta"]["tool_calls"].as_array()
+                    {
                         if !tool_calls.is_empty() {
                             let _ = tx.send(Ok(LlmStreamEvent::ToolCalls)).await;
                         }

--- a/src/router/headless_bridge.rs
+++ b/src/router/headless_bridge.rs
@@ -1,8 +1,9 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use dashmap::DashMap;
 use futures_util::StreamExt;
 use serde_json::json;
@@ -16,8 +17,8 @@ use tracing::{error, info, warn};
 struct HeadlessToolLoopTimeoutError;
 
 use crate::adapter::headless::speech::{
-    detect_audio_format, pcm16_mono_to_wav_bytes, preprocess_stt_text,
-    preprocess_text_message, OpenAiSpeechProvider, OpusSttPipeline,
+    detect_audio_format, pcm16_mono_to_wav_bytes, preprocess_stt_text, preprocess_text_message,
+    OpenAiSpeechProvider, OpusSttPipeline,
 };
 use crate::adapter::headless::tsbot::voice::v1 as voicev1;
 use crate::adapter::headless::INTERNAL_GRPC_ADDR;
@@ -277,6 +278,11 @@ impl HeadlessLlmBridge {
             return Ok(());
         }
 
+        // Omni model: skip STT, send audio directly to LLM
+        if self.config.llm.omni_model {
+            return self.handle_omni_audio_event(client, audio).await;
+        }
+
         let chunk = {
             let mut guard = self.stt_pipeline.lock().await;
             let Some(pipeline) = guard.as_mut() else {
@@ -318,6 +324,44 @@ impl HeadlessLlmBridge {
         self.handle_user_input(client, ctx, text, "voice").await
     }
 
+    /// Handle audio event for omni models (skip STT, send audio directly to LLM)
+    async fn handle_omni_audio_event(
+        &self,
+        client: &mut VoiceServiceClient<Channel>,
+        audio: voicev1::AudioFrameEvent,
+    ) -> Result<()> {
+        let chunk = {
+            let mut guard = self.stt_pipeline.lock().await;
+            let Some(pipeline) = guard.as_mut() else {
+                return Ok(());
+            };
+            pipeline.process_audio_frame(&audio)?
+        };
+
+        let Some(chunk) = chunk else {
+            return Ok(());
+        };
+
+        // Convert audio to WAV and base64 encode
+        let wav_bytes = pcm16_mono_to_wav_bytes(&chunk.pcm16_mono_16k, 16_000);
+        let audio_base64 = BASE64.encode(&wav_bytes);
+        let audio_data = format!("data:audio/wav;base64,{}", audio_base64);
+
+        let mut ctx = self.resolve_caller_from_audio(&audio);
+        ctx.caller_name = chunk.speaker_name;
+
+        info!(
+            event = "headless.omni.audio_input",
+            speaker = %ctx.caller_name,
+            clid = ctx.caller_id,
+            audio_size = wav_bytes.len(),
+            "omni model: sending audio directly to LLM"
+        );
+
+        self.handle_omni_user_input(client, ctx, audio_data, "voice")
+            .await
+    }
+
     async fn handle_user_input(
         &self,
         client: &mut VoiceServiceClient<Channel>,
@@ -325,7 +369,8 @@ impl HeadlessLlmBridge {
         user_msg: String,
         source: &str,
     ) -> Result<()> {
-        if self.config.headless.tts.enabled {
+        // Omni model: skip TTS entirely
+        if !self.config.llm.omni_model && self.config.headless.tts.enabled {
             let _ = client.stop(tonic::Request::new(voicev1::Empty {})).await;
         }
 
@@ -341,9 +386,16 @@ impl HeadlessLlmBridge {
             );
         }
 
-        let stream_tts_enabled = self.config.headless.tts.enabled && self.config.llm.stream_output;
+        // Omni model: skip TTS
+        let stream_tts_enabled = if self.config.llm.omni_model {
+            false
+        } else {
+            self.config.headless.tts.enabled && self.config.llm.stream_output
+        };
+
         let reply = match if stream_tts_enabled {
-            self.run_llm_chain_streaming_tts(client, &ctx, user_msg).await
+            self.run_llm_chain_streaming_tts(client, &ctx, user_msg)
+                .await
         } else {
             self.run_llm_chain(&ctx, user_msg).await
         } {
@@ -358,7 +410,11 @@ impl HeadlessLlmBridge {
         };
         if !reply.trim().is_empty() {
             self.send_reply(client, &ctx, &reply).await?;
-            if self.config.headless.tts.enabled && !stream_tts_enabled {
+            // Omni model: skip TTS
+            if !self.config.llm.omni_model
+                && self.config.headless.tts.enabled
+                && !stream_tts_enabled
+            {
                 if let Err(e) = self.speak_reply(client, &reply).await {
                     warn!("tts playback failed, fallback text only: {e}");
                 }
@@ -386,7 +442,11 @@ impl HeadlessLlmBridge {
 
         let reply = self.run_llm_chain(ctx, user_msg).await?;
         if !reply.trim().is_empty() && self.config.headless.tts.enabled {
-            info!(event = "headless.tts.fallback", reply_len = reply.chars().count(), "fallback to non-streaming tts");
+            info!(
+                event = "headless.tts.fallback",
+                reply_len = reply.chars().count(),
+                "fallback to non-streaming tts"
+            );
             if let Err(e) = self.speak_reply(client, &reply).await {
                 warn!(%e, "fallback tts playback failed, will send text only");
             }
@@ -510,7 +570,11 @@ impl HeadlessLlmBridge {
         Err(HeadlessToolLoopTimeoutError.into())
     }
 
-    fn build_llm_request(&self, ctx: &CallerContext, user_msg: String) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+    fn build_llm_request(
+        &self,
+        ctx: &CallerContext,
+        user_msg: String,
+    ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
         let system_prompt = &self.prompts.system.content;
         let user_ctx = format!(
             "User: {} (uid: {}, clid: {}, groups: {:?}, channel_group: {})",
@@ -526,6 +590,135 @@ impl HeadlessLlmBridge {
             json!({"role":"user","content":user_msg}),
         ];
         (messages, tools)
+    }
+
+    /// Build LLM request for omni models with audio input
+    fn build_omni_llm_request(
+        &self,
+        ctx: &CallerContext,
+        audio_data: String,
+        text_prompt: Option<String>,
+    ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+        let system_prompt = &self.prompts.system.content;
+        let user_ctx = format!(
+            "User: {} (uid: {}, clid: {}, groups: {:?}, channel_group: {})",
+            ctx.caller_name, ctx.caller_uid, ctx.caller_id, ctx.groups, ctx.channel_group_id
+        );
+        let allowed_skills = self
+            .gate
+            .get_allowed_skills(&ctx.groups, ctx.channel_group_id);
+        let tools = self.registry.to_tool_schemas(&allowed_skills);
+
+        let mut content = vec![json!({
+            "type": "input_audio",
+            "input_audio": {
+                "data": audio_data
+            }
+        })];
+
+        if let Some(prompt) = text_prompt {
+            content.push(json!({
+                "type": "text",
+                "text": prompt
+            }));
+        }
+
+        let messages = vec![
+            json!({"role": "system", "content": system_prompt}),
+            json!({"role": "system", "content": user_ctx}),
+            json!({"role": "user", "content": content}),
+        ];
+        (messages, tools)
+    }
+
+    /// Handle user input for omni models (skip TTS, use audio input)
+    async fn handle_omni_user_input(
+        &self,
+        client: &mut VoiceServiceClient<Channel>,
+        ctx: CallerContext,
+        audio_data: String,
+        source: &str,
+    ) -> Result<()> {
+        if Self::OBS_CHAT {
+            info!(
+                event = "headless.omni.user_input",
+                source = source,
+                invoker = %ctx.caller_name,
+                uid = %ctx.caller_uid,
+                clid = ctx.caller_id,
+                "omni model: processing audio input"
+            );
+        }
+
+        let (mut messages, tools) = self.build_omni_llm_request(&ctx, audio_data, None);
+        let max_turns = self.config.bot.max_tool_turns;
+
+        for turn in 0..max_turns {
+            if Self::OBS_LLM {
+                info!(
+                    event = "headless.omni.llm_request",
+                    turn = turn + 1,
+                    messages_count = messages.len(),
+                    tools_count = tools.len(),
+                    "omni llm request"
+                );
+            }
+
+            let response = match self.llm.chat(messages.clone(), tools.clone()).await {
+                Ok(r) => r,
+                Err(e) => {
+                    error!(
+                        event = "headless.omni.llm_error",
+                        turn = turn + 1,
+                        error = %e,
+                        "omni llm request failed"
+                    );
+                    return Err(e);
+                }
+            };
+
+            if response.tool_calls.is_empty() {
+                if let Some(content) = response.content.filter(|c| !c.trim().is_empty()) {
+                    self.send_reply(client, &ctx, &content).await?;
+                    return Ok(());
+                }
+                return Err(anyhow!("empty omni llm response"));
+            }
+
+            // Handle tool calls
+            let assistant_tool_calls: Vec<_> = response
+                .tool_calls
+                .iter()
+                .map(|tc| {
+                    json!({
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": tc.arguments.to_string()
+                        }
+                    })
+                })
+                .collect();
+
+            messages.push(json!({
+                "role": "assistant",
+                "content": response.content,
+                "tool_calls": assistant_tool_calls
+            }));
+
+            for call in &response.tool_calls {
+                let tool_result = self.execute_skill(call, &ctx).await;
+                messages.push(json!({
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "name": call.name,
+                    "content": tool_result
+                }));
+            }
+        }
+
+        Err(HeadlessToolLoopTimeoutError.into())
     }
 
     async fn collect_stream_reply(&self, messages: Vec<serde_json::Value>) -> Result<String> {
@@ -599,7 +792,11 @@ impl HeadlessLlmBridge {
                             let elapsed = start_time.elapsed().as_millis() as i64;
                             first_token_time_clone.store(elapsed, Ordering::Relaxed);
                             if Self::OBS_LLM {
-                                info!(event = "headless.llm.first_token", latency_ms = elapsed, "first token received");
+                                info!(
+                                    event = "headless.llm.first_token",
+                                    latency_ms = elapsed,
+                                    "first token received"
+                                );
                             }
                         }
                         reply.push_str(&token);

--- a/src/router/headless_bridge.rs
+++ b/src/router/headless_bridge.rs
@@ -49,7 +49,7 @@ pub struct HeadlessLlmBridge {
     registry: Arc<SkillRegistry>,
     ts_adapter: Arc<TsAdapter>,
     ts_clients: Arc<DashMap<u32, ClientInfo>>,
-    stt_pipeline: Mutex<Option<OpusSttPipeline>>,
+    audio_pipeline: Mutex<Option<OpusSttPipeline>>,
     speech_provider: Option<OpenAiSpeechProvider>,
 }
 
@@ -77,7 +77,7 @@ impl HeadlessLlmBridge {
         // Create audio pipeline if STT is enabled OR omni_model is true (needs audio framing)
         let need_audio_pipeline = config.headless.stt.enabled || config.llm.omni_model;
         Self {
-            stt_pipeline: Mutex::new(need_audio_pipeline.then(OpusSttPipeline::new)),
+            audio_pipeline: Mutex::new(need_audio_pipeline.then(OpusSttPipeline::new)),
             config,
             prompts,
             gate,
@@ -291,7 +291,7 @@ impl HeadlessLlmBridge {
         }
 
         let chunk = {
-            let mut guard = self.stt_pipeline.lock().await;
+            let mut guard = self.audio_pipeline.lock().await;
             let Some(pipeline) = guard.as_mut() else {
                 return Ok(());
             };
@@ -338,7 +338,7 @@ impl HeadlessLlmBridge {
         audio: voicev1::AudioFrameEvent,
     ) -> Result<()> {
         let chunk = {
-            let mut guard = self.stt_pipeline.lock().await;
+            let mut guard = self.audio_pipeline.lock().await;
             let Some(pipeline) = guard.as_mut() else {
                 warn!(
                     event = "headless.omni.no_pipeline",
@@ -585,12 +585,12 @@ impl HeadlessLlmBridge {
         Err(HeadlessToolLoopTimeoutError.into())
     }
 
-    fn build_llm_request(
+    /// Shared helper: build system prompt, user context, and tools
+    fn build_llm_base_context(
         &self,
         ctx: &CallerContext,
-        user_msg: String,
-    ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
-        let system_prompt = &self.prompts.system.content;
+    ) -> (String, String, Vec<serde_json::Value>) {
+        let system_prompt = self.prompts.system.content.clone();
         let user_ctx = format!(
             "User: {} (uid: {}, clid: {}, groups: {:?}, channel_group: {})",
             ctx.caller_name, ctx.caller_uid, ctx.caller_id, ctx.groups, ctx.channel_group_id
@@ -599,6 +599,15 @@ impl HeadlessLlmBridge {
             .gate
             .get_allowed_skills(&ctx.groups, ctx.channel_group_id);
         let tools = self.registry.to_tool_schemas(&allowed_skills);
+        (system_prompt, user_ctx, tools)
+    }
+
+    fn build_llm_request(
+        &self,
+        ctx: &CallerContext,
+        user_msg: String,
+    ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx);
         let messages = vec![
             json!({"role":"system","content":system_prompt}),
             json!({"role":"system","content":user_ctx}),
@@ -614,15 +623,7 @@ impl HeadlessLlmBridge {
         audio_data: String,
         text_prompt: Option<String>,
     ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
-        let system_prompt = &self.prompts.system.content;
-        let user_ctx = format!(
-            "User: {} (uid: {}, clid: {}, groups: {:?}, channel_group: {})",
-            ctx.caller_name, ctx.caller_uid, ctx.caller_id, ctx.groups, ctx.channel_group_id
-        );
-        let allowed_skills = self
-            .gate
-            .get_allowed_skills(&ctx.groups, ctx.channel_group_id);
-        let tools = self.registry.to_tool_schemas(&allowed_skills);
+        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx);
 
         let mut content = vec![json!({
             "type": "input_audio",

--- a/src/router/headless_bridge.rs
+++ b/src/router/headless_bridge.rs
@@ -74,8 +74,10 @@ impl HeadlessLlmBridge {
         ts_clients: Arc<DashMap<u32, ClientInfo>>,
     ) -> Self {
         let speech_provider = OpenAiSpeechProvider::new(config.clone()).ok();
+        // Create audio pipeline if STT is enabled OR omni_model is true (needs audio framing)
+        let need_audio_pipeline = config.headless.stt.enabled || config.llm.omni_model;
         Self {
-            stt_pipeline: Mutex::new(config.headless.stt.enabled.then(OpusSttPipeline::new)),
+            stt_pipeline: Mutex::new(need_audio_pipeline.then(OpusSttPipeline::new)),
             config,
             prompts,
             gate,
@@ -87,6 +89,11 @@ impl HeadlessLlmBridge {
         }
     }
 
+    /// Check if TTS is effectively enabled (disabled when omni_model is true)
+    fn is_tts_effectively_enabled(&self) -> bool {
+        !self.config.llm.omni_model && self.config.headless.tts.enabled
+    }
+
     pub async fn run(self) -> Result<()> {
         let endpoint = format!("http://{}", INTERNAL_GRPC_ADDR);
         let channel = Channel::from_shared(endpoint.clone())?.connect().await?;
@@ -96,7 +103,7 @@ impl HeadlessLlmBridge {
             include_chat: true,
             include_playback: false,
             include_log: true,
-            include_audio: self.config.headless.stt.enabled,
+            include_audio: self.config.headless.stt.enabled || self.config.llm.omni_model,
         });
 
         let mut stream = client.subscribe_events(req).await?.into_inner();
@@ -333,6 +340,10 @@ impl HeadlessLlmBridge {
         let chunk = {
             let mut guard = self.stt_pipeline.lock().await;
             let Some(pipeline) = guard.as_mut() else {
+                warn!(
+                    event = "headless.omni.no_pipeline",
+                    "omni model: audio pipeline not available, dropping audio frame"
+                );
                 return Ok(());
             };
             pipeline.process_audio_frame(&audio)?
@@ -369,8 +380,8 @@ impl HeadlessLlmBridge {
         user_msg: String,
         source: &str,
     ) -> Result<()> {
-        // Omni model: skip TTS entirely
-        if !self.config.llm.omni_model && self.config.headless.tts.enabled {
+        // Stop TTS if effectively enabled (considers omni_model)
+        if self.is_tts_effectively_enabled() {
             let _ = client.stop(tonic::Request::new(voicev1::Empty {})).await;
         }
 
@@ -386,12 +397,7 @@ impl HeadlessLlmBridge {
             );
         }
 
-        // Omni model: skip TTS
-        let stream_tts_enabled = if self.config.llm.omni_model {
-            false
-        } else {
-            self.config.headless.tts.enabled && self.config.llm.stream_output
-        };
+        let stream_tts_enabled = self.is_tts_effectively_enabled() && self.config.llm.stream_output;
 
         let reply = match if stream_tts_enabled {
             self.run_llm_chain_streaming_tts(client, &ctx, user_msg)
@@ -410,11 +416,7 @@ impl HeadlessLlmBridge {
         };
         if !reply.trim().is_empty() {
             self.send_reply(client, &ctx, &reply).await?;
-            // Omni model: skip TTS
-            if !self.config.llm.omni_model
-                && self.config.headless.tts.enabled
-                && !stream_tts_enabled
-            {
+            if self.is_tts_effectively_enabled() && !stream_tts_enabled {
                 if let Err(e) = self.speak_reply(client, &reply).await {
                     warn!("tts playback failed, fallback text only: {e}");
                 }
@@ -441,7 +443,7 @@ impl HeadlessLlmBridge {
         }
 
         let reply = self.run_llm_chain(ctx, user_msg).await?;
-        if !reply.trim().is_empty() && self.config.headless.tts.enabled {
+        if !reply.trim().is_empty() && self.is_tts_effectively_enabled() {
             info!(
                 event = "headless.tts.fallback",
                 reply_len = reply.chars().count(),
@@ -455,7 +457,29 @@ impl HeadlessLlmBridge {
     }
 
     async fn run_llm_chain(&self, ctx: &CallerContext, user_msg: String) -> Result<String> {
-        let (mut messages, tools) = self.build_llm_request(ctx, user_msg);
+        let (messages, tools) = self.build_llm_request(ctx, user_msg);
+        let (messages, content) = self.execute_llm_with_tools(ctx, messages, tools).await?;
+
+        if let Some(content) = content {
+            return Ok(content);
+        }
+
+        // Try stream reply if no content from chat
+        let stream_reply = self.collect_stream_reply(messages.clone()).await?;
+        if !stream_reply.trim().is_empty() {
+            return Ok(stream_reply);
+        }
+        Err(anyhow!("empty llm response"))
+    }
+
+    /// Shared LLM execution with tool loop
+    /// Returns (messages, content) where content is Some if LLM returned content without tool calls
+    async fn execute_llm_with_tools(
+        &self,
+        ctx: &CallerContext,
+        mut messages: Vec<serde_json::Value>,
+        tools: Vec<serde_json::Value>,
+    ) -> Result<(Vec<serde_json::Value>, Option<String>)> {
         let max_turns = self.config.bot.max_tool_turns;
 
         for turn in 0..max_turns {
@@ -469,7 +493,7 @@ impl HeadlessLlmBridge {
                 );
             }
 
-            let mut response = match self.llm.chat(messages.clone(), tools.clone()).await {
+            let response = match self.llm.chat(messages.clone(), tools.clone()).await {
                 Ok(r) => r,
                 Err(e) => {
                     error!(
@@ -498,20 +522,11 @@ impl HeadlessLlmBridge {
             }
 
             if response.tool_calls.is_empty() {
-                if let Some(content) = response
-                    .content
-                    .take()
-                    .filter(|content| !content.trim().is_empty())
-                {
-                    return Ok(content);
-                }
-                let stream_reply = self.collect_stream_reply(messages.clone()).await?;
-                if !stream_reply.trim().is_empty() {
-                    return Ok(stream_reply);
-                }
-                return Err(anyhow!("empty llm response"));
+                let content = response.content.filter(|c| !c.trim().is_empty());
+                return Ok((messages, content));
             }
 
+            // Build assistant tool calls JSON
             let assistant_tool_calls: Vec<_> = response
                 .tool_calls
                 .iter()
@@ -650,75 +665,15 @@ impl HeadlessLlmBridge {
             );
         }
 
-        let (mut messages, tools) = self.build_omni_llm_request(&ctx, audio_data, None);
-        let max_turns = self.config.bot.max_tool_turns;
+        let (messages, tools) = self.build_omni_llm_request(&ctx, audio_data, None);
+        let (_, content) = self.execute_llm_with_tools(&ctx, messages, tools).await?;
 
-        for turn in 0..max_turns {
-            if Self::OBS_LLM {
-                info!(
-                    event = "headless.omni.llm_request",
-                    turn = turn + 1,
-                    messages_count = messages.len(),
-                    tools_count = tools.len(),
-                    "omni llm request"
-                );
-            }
-
-            let response = match self.llm.chat(messages.clone(), tools.clone()).await {
-                Ok(r) => r,
-                Err(e) => {
-                    error!(
-                        event = "headless.omni.llm_error",
-                        turn = turn + 1,
-                        error = %e,
-                        "omni llm request failed"
-                    );
-                    return Err(e);
-                }
-            };
-
-            if response.tool_calls.is_empty() {
-                if let Some(content) = response.content.filter(|c| !c.trim().is_empty()) {
-                    self.send_reply(client, &ctx, &content).await?;
-                    return Ok(());
-                }
-                return Err(anyhow!("empty omni llm response"));
-            }
-
-            // Handle tool calls
-            let assistant_tool_calls: Vec<_> = response
-                .tool_calls
-                .iter()
-                .map(|tc| {
-                    json!({
-                        "id": tc.id,
-                        "type": "function",
-                        "function": {
-                            "name": tc.name,
-                            "arguments": tc.arguments.to_string()
-                        }
-                    })
-                })
-                .collect();
-
-            messages.push(json!({
-                "role": "assistant",
-                "content": response.content,
-                "tool_calls": assistant_tool_calls
-            }));
-
-            for call in &response.tool_calls {
-                let tool_result = self.execute_skill(call, &ctx).await;
-                messages.push(json!({
-                    "role": "tool",
-                    "tool_call_id": call.id,
-                    "name": call.name,
-                    "content": tool_result
-                }));
-            }
+        if let Some(content) = content {
+            self.send_reply(client, &ctx, &content).await?;
+            return Ok(());
         }
 
-        Err(HeadlessToolLoopTimeoutError.into())
+        Err(anyhow!("empty omni llm response"))
     }
 
     async fn collect_stream_reply(&self, messages: Vec<serde_json::Value>) -> Result<String> {

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -50,6 +50,7 @@ api_key = ""
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
 stream_output = false  # false: 等完整回复后再TTS；true: 边生成边TTS（文字仍完整后一次发送）
+omni_model = false    # 全模态模型：true 时自动禁用 TTS/STT，直接使用语音输入输出
 
 [headless.stt]
 enabled = false

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
@@ -33,6 +33,7 @@ api_key = ""
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
 stream_output = false  # false: wait for full reply before TTS; true: stream LLM output to TTS (text is still sent once after completion)
+omni_model = false    # Omni-modal model: when true, automatically disables TTS/STT and uses voice input/output directly
 
 [headless.stt]
 enabled = false


### PR DESCRIPTION
## Summary by Sourcery

添加无界面（headless）的全模态（omni-modal）LLM 支持，在启用时可直接消费音频并绕过传统的 STT/TTS 流程

New Features:
- 引入 `omni_model` LLM 配置开关，用于启用全模态语音输入/输出处理
- 添加无界面音频处理路径，将分帧音频直接发送给用于全模态的 LLM，包括 WAV/base64 封装以及专用请求构建
- 在文本请求和全模态音频请求之间共享一个通用的 LLM 执行循环，并支持工具调用（tool-call）处理

Enhancements:
- 确保在启用 STT 或激活 `omni_model` 时都会创建音频分帧管线
- 调整 TTS 行为以遵从 `omni_model`，在使用全模态模型时有效地禁用 TTS，并更新流式/非流式的回退逻辑
- 将通用的 LLM 工具调用执行逻辑重构为可复用的辅助方法，用于标准请求和全模态请求
- 改进 TTS、语音和流式逻辑的日志记录与少量格式

Build:
- 添加 `base64` crate 依赖，用于编码音频负载

Documentation:
- 在示例配置以及中英文配置文档中记录新的 `omni_model` 配置选项

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add headless omni-modal LLM support that can consume audio directly and bypass traditional STT/TTS paths when enabled

New Features:
- Introduce an omni_model LLM configuration flag to enable omni-modal voice input/output handling
- Add headless audio handling path that sends framed audio directly to the LLM for omni models, including WAV/base64 packaging and dedicated request building
- Share a generic LLM execution loop with tool-call handling between text and omni-modal audio requests

Enhancements:
- Ensure audio framing pipeline is created when either STT is enabled or omni_model is active
- Adjust TTS behavior to respect omni_model by effectively disabling TTS when omni models are used and updating streaming/non-streaming fallback logic
- Refactor common LLM tool-call execution into a reusable helper for both standard and omni-modal requests
- Improve logging and minor formatting for TTS, speech, and streaming logic

Build:
- Add base64 crate dependency for encoding audio payloads

Documentation:
- Document the new omni_model configuration option in example settings and both Chinese and English configuration docs

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加无界面（headless）的全模态（omni-modal）LLM 支持，在启用时可直接消费音频并绕过传统的 STT/TTS 流程

New Features:
- 引入 `omni_model` LLM 配置开关，用于启用全模态语音输入/输出处理
- 添加无界面音频处理路径，将分帧音频直接发送给用于全模态的 LLM，包括 WAV/base64 封装以及专用请求构建
- 在文本请求和全模态音频请求之间共享一个通用的 LLM 执行循环，并支持工具调用（tool-call）处理

Enhancements:
- 确保在启用 STT 或激活 `omni_model` 时都会创建音频分帧管线
- 调整 TTS 行为以遵从 `omni_model`，在使用全模态模型时有效地禁用 TTS，并更新流式/非流式的回退逻辑
- 将通用的 LLM 工具调用执行逻辑重构为可复用的辅助方法，用于标准请求和全模态请求
- 改进 TTS、语音和流式逻辑的日志记录与少量格式

Build:
- 添加 `base64` crate 依赖，用于编码音频负载

Documentation:
- 在示例配置以及中英文配置文档中记录新的 `omni_model` 配置选项

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add headless omni-modal LLM support that can consume audio directly and bypass traditional STT/TTS paths when enabled

New Features:
- Introduce an omni_model LLM configuration flag to enable omni-modal voice input/output handling
- Add headless audio handling path that sends framed audio directly to the LLM for omni models, including WAV/base64 packaging and dedicated request building
- Share a generic LLM execution loop with tool-call handling between text and omni-modal audio requests

Enhancements:
- Ensure audio framing pipeline is created when either STT is enabled or omni_model is active
- Adjust TTS behavior to respect omni_model by effectively disabling TTS when omni models are used and updating streaming/non-streaming fallback logic
- Refactor common LLM tool-call execution into a reusable helper for both standard and omni-modal requests
- Improve logging and minor formatting for TTS, speech, and streaming logic

Build:
- Add base64 crate dependency for encoding audio payloads

Documentation:
- Document the new omni_model configuration option in example settings and both Chinese and English configuration docs

</details>

</details>