### PR TITLE
feat(serverquery): add auto-reconnect on connection loss

### DIFF
--- a/src/adapter/headless/service.rs
+++ b/src/adapter/headless/service.rs
@@ -180,10 +180,7 @@ async fn stream_tts_audio_loop(
             });
         }
 
-        let stdin_result = child
-            .child
-            .as_mut()
-            .and_then(|c| c.stdin.take());
+        let stdin_result = child.child.as_mut().and_then(|c| c.stdin.take());
         let mut stdin = match stdin_result {
             Some(s) => s,
             None => {
@@ -662,7 +659,10 @@ impl VoiceService for VoiceServiceImpl {
     async fn subscribe_events(
         &self,
         req: Request<voicev1::SubscribeRequest>,
-    ) -> std::result::Result<Response<<VoiceServiceImpl as VoiceService>::SubscribeEventsStream>, Status> {
+    ) -> std::result::Result<
+        Response<<VoiceServiceImpl as VoiceService>::SubscribeEventsStream>,
+        Status,
+    > {
         let cfg = req.into_inner();
         let rx = self.events_tx.subscribe();
         let stream = BroadcastStream::new(rx).filter_map(move |r| {

--- a/src/adapter/napcat/mod.rs
+++ b/src/adapter/napcat/mod.rs
@@ -5,13 +5,11 @@ pub mod ws;
 
 pub use ws::NapCatAdapter;
 
-use std::sync::Arc;
-use anyhow::Result;
 use crate::config::AppConfig;
+use anyhow::Result;
+use std::sync::Arc;
 
-pub async fn connect_if_enabled(
-    config: Arc<AppConfig>,
-) -> Result<Option<Arc<NapCatAdapter>>> {
+pub async fn connect_if_enabled(config: Arc<AppConfig>) -> Result<Option<Arc<NapCatAdapter>>> {
     if config.napcat.enabled {
         let nc = NapCatAdapter::connect(config.napcat.clone()).await?;
         Ok(Some(nc))

--- a/src/adapter/serverquery/connection.rs
+++ b/src/adapter/serverquery/connection.rs
@@ -14,7 +14,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader},
     net::TcpStream,
-    sync::{broadcast, oneshot, Mutex},
+    sync::{broadcast, mpsc, oneshot, Mutex},
     time::sleep,
 };
 use tracing::{debug, error, info, warn};
@@ -158,6 +158,8 @@ pub struct TsAdapter {
     query_active: AtomicBool,
     include_event_lines_active: AtomicBool,
     query_lock: Mutex<()>,
+    reconnect_tx: mpsc::Sender<()>,
+    config: Arc<AppConfig>,
 }
 
 impl TsAdapter {
@@ -178,6 +180,7 @@ impl TsAdapter {
         let stream = Self::connect_with_retry(cfg, method).await?;
         let (reader, writer) = tokio::io::split(stream);
         let (tx, _) = broadcast::channel::<TsEvent>(256);
+        let (reconnect_tx, reconnect_rx) = mpsc::channel::<()>(1);
 
         let adapter = Arc::new(Self {
             writer: Mutex::new(writer),
@@ -187,24 +190,33 @@ impl TsAdapter {
             query_active: AtomicBool::new(false),
             include_event_lines_active: AtomicBool::new(false),
             query_lock: Mutex::new(()),
+            reconnect_tx,
+            config: config.clone(),
         });
 
-        let adapter_clone = adapter.clone();
-        tokio::spawn(async move {
-            adapter_clone.reader_loop(BufReader::new(reader)).await;
-        });
+        Self::spawn_loops(adapter.clone(), reader);
 
         if let Err(e) = adapter.init(cfg).await {
             error!("Failed to initialize TeamSpeak session: {e}");
             return Err(e);
         }
 
+        let weak = Arc::downgrade(&adapter);
+        tokio::spawn(Self::reconnect_loop(weak, reconnect_rx));
+
+        Ok(adapter)
+    }
+
+    fn spawn_loops(adapter: Arc<TsAdapter>, reader: tokio::io::ReadHalf<TsStream>) {
+        let adapter_clone = adapter.clone();
+        tokio::spawn(async move {
+            adapter_clone.reader_loop(BufReader::new(reader)).await;
+        });
+
         let adapter_clone = adapter.clone();
         tokio::spawn(async move {
             adapter_clone.keepalive_loop().await;
         });
-
-        Ok(adapter)
     }
 
     async fn connect_with_retry(cfg: &SqConfig, method: TsMethod) -> Result<TsStream> {
@@ -262,6 +274,49 @@ impl TsAdapter {
 
         let stream = channel.into_stream();
         Ok(TsStream::Ssh(stream))
+    }
+
+    async fn reconnect_loop(weak: std::sync::Weak<TsAdapter>, mut rx: mpsc::Receiver<()>) {
+        const MAX_RETRIES: u32 = 10;
+        while rx.recv().await.is_some() {
+            let Some(adapter) = weak.upgrade() else { break };
+            info!("ServerQuery reconnecting...");
+
+            let mut delay = Duration::from_secs(1);
+            for attempt in 0..MAX_RETRIES {
+                match Self::do_reconnect(&adapter).await {
+                    Ok(()) => {
+                        info!("ServerQuery reconnected");
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[{}/{}] ServerQuery reconnect failed: {}",
+                            attempt + 1,
+                            MAX_RETRIES,
+                            e
+                        );
+                        sleep(delay).await;
+                        delay = (delay * 2).min(Duration::from_secs(60));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn do_reconnect(adapter: &Arc<TsAdapter>) -> Result<()> {
+        let cfg = &adapter.config.serverquery;
+        let method = TsMethod::try_from(cfg.method.as_str())
+            .context("Invalid connection method in config")?;
+
+        let stream = Self::connect_with_retry(cfg, method).await?;
+        let (reader, writer) = tokio::io::split(stream);
+
+        *adapter.writer.lock().await = writer;
+        Self::spawn_loops(adapter.clone(), reader);
+
+        adapter.init(cfg).await?;
+        Ok(())
     }
 
     async fn init(&self, cfg: &SqConfig) -> Result<()> {
@@ -338,18 +393,16 @@ impl TsAdapter {
             }
 
             match tokio::time::timeout_at(deadline, rx.recv()).await {
-                Ok(Ok(event)) => {
-                    match event {
-                        TsEvent::ClientEnterView(client) if client.clid != 0 => {
-                            debug!(
-                                "fetch_client_snapshot: got client clid={}, nickname={}",
-                                client.clid, client.client_nickname
-                            );
-                            clients.push(client);
-                        }
-                        _ => {}
+                Ok(Ok(event)) => match event {
+                    TsEvent::ClientEnterView(client) if client.clid != 0 => {
+                        debug!(
+                            "fetch_client_snapshot: got client clid={}, nickname={}",
+                            client.clid, client.client_nickname
+                        );
+                        clients.push(client);
                     }
-                }
+                    _ => {}
+                },
                 Ok(Err(_)) => {
                     // channel closed
                     break;
@@ -361,10 +414,7 @@ impl TsAdapter {
             }
         }
 
-        info!(
-            "fetch_client_snapshot: returning {} clients",
-            clients.len()
-        );
+        info!("fetch_client_snapshot: returning {} clients", clients.len());
 
         Ok(clients)
     }
@@ -455,7 +505,8 @@ impl TsAdapter {
 
                     // 查询活跃时，收集数据行
                     let query_active = self.query_active.load(Ordering::Relaxed);
-                    let include_event_lines = self.include_event_lines_active.load(Ordering::Relaxed);
+                    let include_event_lines =
+                        self.include_event_lines_active.load(Ordering::Relaxed);
                     if query_active && (!is_event || include_event_lines) {
                         result_lines.push(trimmed.to_string());
                     }
@@ -518,6 +569,8 @@ impl TsAdapter {
                 }
             }
         }
+        error!("ServerQuery reader loop exited");
+        let _ = self.reconnect_tx.try_send(());
     }
 
     async fn keepalive_loop(&self) {
@@ -526,6 +579,7 @@ impl TsAdapter {
             sleep(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)).await;
             if let Err(e) = self.send_raw("whoami").await {
                 error!("Keepalive failed: {e}");
+                break;
             }
         }
     }

--- a/src/adapter/serverquery/connection.rs
+++ b/src/adapter/serverquery/connection.rs
@@ -160,6 +160,7 @@ pub struct TsAdapter {
     query_lock: Mutex<()>,
     reconnect_tx: mpsc::Sender<()>,
     config: Arc<AppConfig>,
+    generation: AtomicU32,
 }
 
 impl TsAdapter {
@@ -192,6 +193,7 @@ impl TsAdapter {
             query_lock: Mutex::new(()),
             reconnect_tx,
             config: config.clone(),
+            generation: AtomicU32::new(0),
         });
 
         Self::spawn_loops(adapter.clone(), reader);
@@ -208,14 +210,16 @@ impl TsAdapter {
     }
 
     fn spawn_loops(adapter: Arc<TsAdapter>, reader: tokio::io::ReadHalf<TsStream>) {
+        let gen = adapter.generation.fetch_add(1, Ordering::Relaxed) + 1;
+
         let adapter_clone = adapter.clone();
         tokio::spawn(async move {
-            adapter_clone.reader_loop(BufReader::new(reader)).await;
+            adapter_clone.reader_loop(gen, BufReader::new(reader)).await;
         });
 
         let adapter_clone = adapter.clone();
         tokio::spawn(async move {
-            adapter_clone.keepalive_loop().await;
+            adapter_clone.keepalive_loop(gen).await;
         });
     }
 
@@ -283,10 +287,12 @@ impl TsAdapter {
             info!("ServerQuery reconnecting...");
 
             let mut delay = Duration::from_secs(1);
+            let mut success = false;
             for attempt in 0..MAX_RETRIES {
                 match Self::do_reconnect(&adapter).await {
                     Ok(()) => {
                         info!("ServerQuery reconnected");
+                        success = true;
                         break;
                     }
                     Err(e) => {
@@ -300,6 +306,12 @@ impl TsAdapter {
                         delay = (delay * 2).min(Duration::from_secs(60));
                     }
                 }
+            }
+            if !success {
+                error!(
+                    "ServerQuery reconnect exhausted all {} attempts, giving up",
+                    MAX_RETRIES
+                );
             }
         }
     }
@@ -454,7 +466,7 @@ impl TsAdapter {
         self.event_tx.subscribe()
     }
 
-    async fn reader_loop(&self, mut reader: BufReader<tokio::io::ReadHalf<TsStream>>) {
+    async fn reader_loop(&self, _gen: u32, mut reader: BufReader<tokio::io::ReadHalf<TsStream>>) {
         let mut line = String::new();
         let mut result_lines: Vec<String> = Vec::new();
         let mut waiting_for_data = false; // 收到 error 行后，等待可能延迟的数据行
@@ -573,12 +585,17 @@ impl TsAdapter {
         let _ = self.reconnect_tx.try_send(());
     }
 
-    async fn keepalive_loop(&self) {
+    async fn keepalive_loop(&self, gen: u32) {
         const KEEPALIVE_INTERVAL_SECS: u64 = 180;
         loop {
             sleep(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)).await;
+            if self.generation.load(Ordering::Relaxed) != gen {
+                debug!("Keepalive loop exiting (generation mismatch)");
+                break;
+            }
             if let Err(e) = self.send_raw("whoami").await {
                 error!("Keepalive failed: {e}");
+                let _ = self.reconnect_tx.try_send(());
                 break;
             }
         }

--- a/src/router/sq_router.rs
+++ b/src/router/sq_router.rs
@@ -126,7 +126,10 @@ impl EventRouter {
                     });
                 }
                 TsEvent::ClientEnterView(e) => {
-                    info!("Client entered view: clid={}, nickname={}", e.clid, e.client_nickname);
+                    info!(
+                        "Client entered view: clid={}, nickname={}",
+                        e.clid, e.client_nickname
+                    );
                     self.cache_client(
                         e.clid,
                         e.cldbid,


### PR DESCRIPTION
Add reconnect loop with exponential backoff (max 10 retries, max 60s delay).
When reader loop exits or keepalive fails, trigger reconnection attempt.

## Summary by Sourcery

为 ServerQuery 适配器在连接丢失时添加自动重连功能，包括重连循环编排和日志改进。

新功能：
- 为 ServerQuery 适配器引入自动重连循环，当读取循环退出或 keepalive 失败时触发。
- 添加重连逻辑，用于重新建立 ServerQuery 连接、重启后台循环并重新初始化会话。

增强改进：
- 在 ServerQuery 重连尝试中使用带上限重试次数和延迟的指数退避策略。
- 在 ServerQuery 适配器中捕获共享应用配置，以支持在无需外部输入的情况下进行重连尝试。
- 优化各模块中的日志记录和格式，以提升可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic reconnection for the ServerQuery adapter when the connection is lost, including reconnect loop orchestration and logging improvements.

New Features:
- Introduce an auto-reconnect loop for the ServerQuery adapter that triggers when the reader loop exits or keepalive fails.
- Add reconnection logic that re-establishes the ServerQuery connection, restarts background loops, and reinitializes the session.

Enhancements:
- Use exponential backoff with bounded retries and delay for ServerQuery reconnection attempts.
- Capture shared application configuration in the ServerQuery adapter to support reconnection attempts without external input.
- Tidy up logging and formatting in various modules for improved readability.

</details>