### PR TITLE
feat: Skip STT processing during music playback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 - 格式化: `cargo fmt`
 - 清理构建: `cargo clean`
 
+## 开发提醒
+
+- 修改 `headless_bridge.rs` 的音频/STT 逻辑时，注意 **多模态模型 (`omni_model`)** 和 **纯文本模型** 走不同代码路径：`handle_omni_audio_event` / `handle_audio_event`，需两处同步修改
+- `music_backend.ignore_stt_playing` 在 `headless_bridge.rs` 的 `handle_audio_event` 中**统一拦截**（omni 路径之前），一处修改覆盖两种模型
+
 ## 项目架构
 
 ```
@@ -24,7 +29,7 @@ src/
 │   ├── serverquery/    # TeamSpeak ServerQuery (TCP/SSH)
 │   ├── napcat/         # NapCat OneBot 11 (WebSocket)
 │   └── headless/       # 语音桥接服务
-├── llm/                # LLM 引擎 (OpenAI 兼容)
+├── llm/                # LLM 引擎 (OpenAI 兼容)，流式解析不处理 reasoning_content（不需要思考过程）
 ├── permission/         # 权限门控
 └── skills/             # 技能系统 (music, moderation, information, communication)
 ```

--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -65,6 +65,7 @@ burst_size = 3
 # 日志配置
 [logging]
 file_level = "info"
+max_log_days = 7  # 日志保留天数，超出自动删除
 
 # 联动项目配置
 # 音乐后端配置

--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -42,8 +42,7 @@ channel_id = ""
 [headless.stt]
 enabled = false
 provider = "openai-compatibility"
-base_url = "http://stt-api:9000/inference"  # 本地 whisper.cpp 服务（Docker Compose 部署）
-# base_url = ""  # OpenAI 兼容的在线 STT 服务地址
+base_url = "http://stt-api:9000/inference"  # 本地 whisper.cpp 服务（Docker Compose 部署） / OpenAI 兼容的在线 STT 服务地址
 api_key = ""  # 本地服务无需 API Key，在线服务需填写
 model = "ggml-large-v3-turbo"  # whisper 模型名称（本地）/ 在线服务的模型名称
 language = "zh"  # 语言代码：zh(中文), en(英语), ja(日语), ko(韩语) 等
@@ -73,6 +72,7 @@ file_level = "info"
 backend = "ncm_api"  # "ts3audiobot"（通过 TS 私信控制）或 "tsbot_backend"（NeteaseTSBot）或 "ncm_api"（内置播放）
 base_url = "http://127.0.0.1:8009"   # backend = "tsbot_backend" 时生效
 musicbot_name = "TS3AudioBot"  # 音乐机器人名称，其音频不会被送入 STT
+ignore_stt_playing = false  # true: 播放音乐时忽略 STT 语音输入，防止 TTS 打断音乐
 
 # NCM API 专属配置（backend = "ncm_api" 时生效）
 [music_ncm_api]

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -3,12 +3,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LogConfig {
     pub file_level: String,
+    pub max_log_days: u32,
 }
 
 impl Default for LogConfig {
     fn default() -> Self {
         Self {
             file_level: "debug".to_string(),
+            max_log_days: 7,
         }
     }
 }

--- a/src/config/music_backend.rs
+++ b/src/config/music_backend.rs
@@ -6,6 +6,7 @@ pub struct MusicBackendConfig {
     pub backend: String,
     pub base_url: String,
     pub musicbot_name: String,
+    pub ignore_stt_playing: bool,
 }
 
 impl Default for MusicBackendConfig {
@@ -14,6 +15,7 @@ impl Default for MusicBackendConfig {
             backend: "ts3audiobot".to_string(),
             base_url: "http://127.0.0.1:8009".to_string(),
             musicbot_name: "TS3AudioBot".to_string(),
+            ignore_stt_playing: false,
         }
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,6 @@
 use chrono::Local;
 use slog::Drain;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -13,15 +13,43 @@ use tracing_subscriber::{
     EnvFilter, Layer,
 };
 
-pub fn init_tracing(console_level: &str, file_level: &str) -> WorkerGuard {
+fn cleanup_old_logs(log_dir: &PathBuf, max_days: u32) {
+    let now = chrono::Local::now();
+    let entries = match fs::read_dir(log_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map_or(false, |n| n.starts_with("tsclaw-") && n.ends_with(".log"))
+        {
+            continue;
+        }
+        if let Ok(meta) = fs::metadata(&path) {
+            if let Ok(modified) = meta.modified() {
+                let age = now.signed_duration_since::<chrono::Local>(
+                    chrono::DateTime::<chrono::Local>::from(modified),
+                );
+                if age.num_days() >= max_days as i64 {
+                    let _ = fs::remove_file(&path);
+                }
+            }
+        }
+    }
+}
+
+pub fn init_tracing(console_level: &str, file_level: &str, max_log_days: u32) -> WorkerGuard {
     let console_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(console_level))
         .add_directive("russh::client=off".parse().unwrap())
         .add_directive("russh=off".parse().unwrap())
-        .add_directive("tsclientlib=debug".parse().unwrap())
-        .add_directive("tsproto=debug".parse().unwrap())
-        .add_directive("tsproto-packets=debug".parse().unwrap())
-        .add_directive("ts-bookkeeping=debug".parse().unwrap())
+        .add_directive("tsclientlib=off".parse().unwrap())
+        .add_directive("tsproto=off".parse().unwrap())
+        .add_directive("tsproto-packets=off".parse().unwrap())
+        .add_directive("ts-bookkeeping=off".parse().unwrap())
         .add_directive("h2=off".parse().unwrap());
 
     let console_layer = fmt::layer()
@@ -37,7 +65,9 @@ pub fn init_tracing(console_level: &str, file_level: &str) -> WorkerGuard {
         .join("logs");
     let _ = std::fs::create_dir_all(&log_dir);
 
-    let file_appender = DailyFileAppender::new(log_dir, "tsclaw");
+    cleanup_old_logs(&log_dir, max_log_days);
+
+    let file_appender = DailyFileAppender::new(log_dir.clone(), "tsclaw");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let file_filter = EnvFilter::new(file_level).add_directive("h2=off".parse().unwrap());
@@ -57,6 +87,17 @@ pub fn init_tracing(console_level: &str, file_level: &str) -> WorkerGuard {
     let slog_logger = slog::Logger::root(TracingSlogDrain.fuse(), slog::o!());
     let _slog_guard = slog_scope::set_global_logger(slog_logger);
     std::mem::forget(_slog_guard);
+
+    // Periodic cleanup
+    {
+        let dir = log_dir;
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(86400)).await;
+                cleanup_old_logs(&dir, max_log_days);
+            }
+        });
+    }
 
     guard
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let config_dir = crate::config::config_dir();
     let cfg = AppConfig::load(config_dir.join("settings.toml"))?;
-    let _guard = crate::log::init_tracing(&args.log_level, &cfg.logging.file_level);
+    let _guard = crate::log::init_tracing(&args.log_level, &cfg.logging.file_level, cfg.logging.max_log_days);
 
     info!("Starting TeamSpeakClaw v{}", env!("CARGO_PKG_VERSION"));
 

--- a/src/router/headless_bridge.rs
+++ b/src/router/headless_bridge.rs
@@ -205,6 +205,24 @@ impl HeadlessLlmBridge {
         self.config.headless.tts.enabled && self.speech_provider.is_some()
     }
 
+    async fn should_ignore_stt_while_playing(
+        &self,
+        client: &mut VoiceServiceClient<Channel>,
+    ) -> bool {
+        if !self.config.music_backend.ignore_stt_playing {
+            return false;
+        }
+        match client.get_status(tonic::Request::new(voicev1::Empty {})).await {
+            Ok(rsp) => {
+                rsp.into_inner().state() == voicev1::status_response::State::Playing
+            }
+            Err(e) => {
+                warn!("ignore_stt_playing: get_status failed: {e}");
+                false
+            }
+        }
+    }
+
     pub async fn run(self) -> Result<()> {
         let endpoint = format!("http://{}", INTERNAL_GRPC_ADDR);
         let channel = Channel::from_shared(endpoint.clone())?.connect().await?;
@@ -394,6 +412,10 @@ impl HeadlessLlmBridge {
         let musicbot_name = &self.config.music_backend.musicbot_name;
         if !musicbot_name.is_empty() && musicbot_name.eq_ignore_ascii_case(&audio.from_client_name)
         {
+            return Ok(());
+        }
+
+        if self.should_ignore_stt_while_playing(client).await {
             return Ok(());
         }
 

--- a/src/router/headless_bridge.rs
+++ b/src/router/headless_bridge.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -165,6 +165,7 @@ pub struct HeadlessLlmBridge {
     ts_clients: Arc<DashMap<u32, ClientInfo>>,
     audio_pipeline: Mutex<Option<OpusSttPipeline>>,
     speech_provider: Option<Arc<OpenAiSpeechProvider>>,
+    playback_status_cache: Mutex<(Instant, bool)>,
 }
 
 impl HeadlessLlmBridge {
@@ -198,6 +199,7 @@ impl HeadlessLlmBridge {
             ts_adapter,
             ts_clients,
             speech_provider,
+            playback_status_cache: Mutex::new((Instant::now(), false)),
         }
     }
 
@@ -212,12 +214,23 @@ impl HeadlessLlmBridge {
         if !self.config.music_backend.ignore_stt_playing {
             return false;
         }
+
+        {
+            let cache = self.playback_status_cache.lock().await;
+            if cache.0.elapsed() < Duration::from_secs(1) {
+                return cache.1;
+            }
+        }
+
         match client.get_status(tonic::Request::new(voicev1::Empty {})).await {
             Ok(rsp) => {
-                rsp.into_inner().state() == voicev1::status_response::State::Playing
+                let playing = rsp.into_inner().state() == voicev1::status_response::State::Playing;
+                let mut cache = self.playback_status_cache.lock().await;
+                *cache = (Instant::now(), playing);
+                playing
             }
             Err(e) => {
-                warn!("ignore_stt_playing: get_status failed: {e}");
+                debug!("ignore_stt_playing: get_status failed: {e}");
                 false
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

根据可配置的后端设置，在音乐播放活动时跳过 STT 处理，并更新相关文档和示例配置。

New Features:
- 在 headless bridge 中新增可配置选项，在音乐播放时忽略 STT 输入。
- 在音乐后端配置中新增 `ignore_stt_playing` 标志位，包含默认值和示例配置接线。

Enhancements:
- 在 headless 音频处理里集中管理音频/STT 拦截逻辑，以同时覆盖 omni 和纯文本模型。
- 在 `AGENTS.md` 中澄清有关 headless 音频/STT 代码路径和 LLM 流式行为的文档说明。
- 在示例设置配置中澄清 STT `base_url` 的用法，以同时覆盖本地和在线服务。

Documentation:
- 在 `AGENTS.md` 中记录 omni 与纯文本音频/STT 路径，以及集中化的 STT 忽略行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip STT processing when music playback is active based on configurable backend settings and update related documentation and example config.

New Features:
- Add configurable option to ignore STT input while music is playing in the headless bridge.
- Add a new ignore_stt_playing flag to the music backend configuration with default value and sample config wiring.

Enhancements:
- Centralize audio/STT interception in headless audio handling to cover both omni and text-only models.
- Clarify documentation around headless audio/STT code paths and LLM streaming behavior in AGENTS.md.
- Clarify STT base_url usage in the example settings config to cover both local and online services.

Documentation:
- Document omni vs text-only audio/STT paths and centralized STT ignore behavior in AGENTS.md.

</details>