### PR TITLE
feat: add yt-dlp video URL playback support

### DIFF
--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -87,6 +87,7 @@ unm_search_mode = "fast-first"           # fast-first（速度优先）或 order
 unm_proxy_uri = ""                       # 代理地址（如 https://proxy.example.com）
 unm_joox_cookie = ""                     # JOOX cookie（需要时填写）
 unm_qq_cookie = ""                       # QQ cookie（需要时填写）
+yt_dlp_path = "yt-dlp"                   # yt-dlp 可执行文件路径（play_url/queue_url 使用）
 
 # NapCat 配置（可选，用于 QQ 机器人功能）
 # 前置要求：安装并运行 NapCat（https://napneko.github.io/）

--- a/src/config/music_ncm_api.rs
+++ b/src/config/music_ncm_api.rs
@@ -11,6 +11,7 @@ pub struct MusicNcmApiConfig {
     pub unm_proxy_uri: String,
     pub unm_joox_cookie: String,
     pub unm_qq_cookie: String,
+    pub yt_dlp_path: String,
 }
 
 impl Default for MusicNcmApiConfig {
@@ -24,6 +25,7 @@ impl Default for MusicNcmApiConfig {
             unm_proxy_uri: String::new(),
             unm_joox_cookie: String::new(),
             unm_qq_cookie: String::new(),
+            yt_dlp_path: "yt-dlp".to_string(),
         }
     }
 }

--- a/src/skills/music/mod.rs
+++ b/src/skills/music/mod.rs
@@ -167,7 +167,7 @@ fn ncm_api_schema() -> Value {
             },
             "play_now": {
                 "type": "boolean",
-                "description": "If true, play immediately instead of appending to queue."
+                "description": "If true, play immediately instead of appending to queue. Used by queue_netease and queue_url."
             },
             "limit": {
                 "type": "integer",

--- a/src/skills/music/mod.rs
+++ b/src/skills/music/mod.rs
@@ -61,7 +61,10 @@ impl Skill for MusicControl {
         match self.backend.as_str() {
             "ncm_api" => "Control the music player. Search, play, and manage a song queue from NetEase Music (网易云). \
                           Supports playback control (play/pause/next/previous), queue management, repeat/shuffle modes, \
-                          volume and audio effects. When there are multiple search results, directly play the first best match.",
+                          volume and audio effects. When there are multiple search results, directly play the first best match. \
+                          Also supports playing audio from video links (YouTube, Bilibili, etc.) via play_url/queue_url \
+                          using yt-dlp. When the user provides a video URL, use play_url to play immediately; \
+                          for multiple URLs, play_url the first and queue_url the rest.",
             "ts3audiobot" => "Control the TS3AudioBot music player via chat commands. \
                              Use ts_* actions to play songs, manage playlists, and switch modes.",
             "tsbot_backend" => "Control the NeteaseTSBot music player. Search and play songs from NetEase Music and QQ Music, \
@@ -130,9 +133,12 @@ fn ncm_api_schema() -> Value {
             "action": {
                 "type": "string",
                 "description": "The action to perform. Use 'search' to find songs, then 'play' with the song_id. \
-                               Use 'queue_netease' to add songs to the queue.",
+                               Use 'queue_netease' to add songs to the queue. \
+                               When the user provides a video URL (YouTube, Bilibili, etc.), use 'play_url' to play \
+                               immediately or 'queue_url' (with play_now=true/false) to add to queue.",
                 "enum": [
                     "search", "play", "queue_netease",
+                    "play_url", "queue_url",
                     "next", "previous",
                     "repeat", "shuffle",
                     "pause", "stop", "seek",
@@ -146,6 +152,10 @@ fn ncm_api_schema() -> Value {
             "song_id": {
                 "type": "string",
                 "description": "NetEase song ID. Required for 'play' and 'queue_netease'."
+            },
+            "url": {
+                "type": "string",
+                "description": "Video URL (required for 'play_url' and 'queue_url'). Supports all yt-dlp compatible platforms."
             },
             "title": {
                 "type": "string",

--- a/src/skills/music/ncm_api.rs
+++ b/src/skills/music/ncm_api.rs
@@ -232,36 +232,19 @@ async fn queue_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
         .ok_or_else(|| anyhow::anyhow!("Missing url"))?;
     let play_now = args["play_now"].as_bool().unwrap_or(false);
 
-    let song_info = SongInfo {
-        id: url.to_string(),
-        name: String::new(),
-        artist: String::new(),
-        is_url: true,
-    };
-
-    let insert_index = {
-        let mut state = player_state().lock().unwrap();
-        let idx = state.queue.len();
-        state.queue.push(song_info);
-        if play_now {
-            state.current_index = idx;
-        }
-        idx
-    };
-
     if play_now {
-        let item = {
-            let state = player_state().lock().unwrap();
-            state.queue[state.current_index].clone()
-        };
-        let (audio_url, title, channel) = resolve_url(&item.id, cfg).await?;
+        // 先解析 URL，成功后再修改队列状态
+        let (audio_url, title, channel) = resolve_url(url, cfg).await?;
         let display_title = format_title(&title, &channel);
-        // Update the queue item with resolved info
         {
             let mut state = player_state().lock().unwrap();
-            let idx = state.current_index;
-            state.queue[idx].name = title;
-            state.queue[idx].artist = channel;
+            state.queue.push(SongInfo {
+                id: url.to_string(),
+                name: title,
+                artist: channel,
+                is_url: true,
+            });
+            state.current_index = state.queue.len() - 1;
         }
         let mut result = serde_json::json!({
             "status": "playing",
@@ -272,6 +255,20 @@ async fn queue_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
         result[PLAY_TITLE_KEY] = serde_json::Value::String(display_title);
         return Ok(result);
     }
+
+    // play_now=false: 直接入队，不解析
+    let song_info = SongInfo {
+        id: url.to_string(),
+        name: String::new(),
+        artist: String::new(),
+        is_url: true,
+    };
+    let insert_index = {
+        let mut state = player_state().lock().unwrap();
+        let idx = state.queue.len();
+        state.queue.push(song_info);
+        idx
+    };
 
     Ok(serde_json::json!({
         "status": "queued",
@@ -669,6 +666,11 @@ async fn resolve_url(url: &str, cfg: &MusicNcmApiConfig) -> Result<(String, Stri
     .await
     .map_err(|_| anyhow::anyhow!("yt-dlp 元数据解析超时 (60s)"))?
     .map_err(|e| anyhow::anyhow!("yt-dlp 执行失败: {}", e))?;
+
+    if !meta_output.status.success() {
+        let stderr = String::from_utf8_lossy(&meta_output.stderr);
+        return Err(anyhow::anyhow!("yt-dlp 元数据解析失败: {}", stderr.trim()));
+    }
 
     let meta_stdout = String::from_utf8_lossy(&meta_output.stdout);
     let mut lines = meta_stdout.lines();

--- a/src/skills/music/ncm_api.rs
+++ b/src/skills/music/ncm_api.rs
@@ -16,6 +16,7 @@ struct SongInfo {
     name: String,
     artist: String,
     is_url: bool,
+    resolved_url: Option<String>,
 }
 
 /// 播放模式（对齐 ts3audiobot）
@@ -210,6 +211,7 @@ async fn play_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
             name: title.clone(),
             artist: channel.clone(),
             is_url: true,
+            resolved_url: Some(audio_url.clone()),
         });
         state.current_index = state.queue.len() - 1;
     }
@@ -243,6 +245,7 @@ async fn queue_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
                 name: title,
                 artist: channel,
                 is_url: true,
+                resolved_url: Some(audio_url.clone()),
             });
             state.current_index = state.queue.len() - 1;
         }
@@ -262,6 +265,7 @@ async fn queue_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
         name: String::new(),
         artist: String::new(),
         is_url: true,
+        resolved_url: None,
     };
     let insert_index = {
         let mut state = player_state().lock().unwrap();
@@ -293,6 +297,7 @@ async fn queue_netease(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
         name: title.to_string(),
         artist: artist.to_string(),
         is_url: false,
+        resolved_url: None,
     };
 
     // 添加到队列并获取插入位置
@@ -381,8 +386,20 @@ async fn next(cfg: &MusicNcmApiConfig) -> Result<Value> {
     };
 
     let (audio_url, display_title, song_id) = if song.is_url {
-        let (url, title, channel) = resolve_url(&song.id, cfg).await?;
-        (url, format_title(&title, &channel), song.id.clone())
+        if let Some(cached) = &song.resolved_url {
+            (cached.clone(), format_title(&song.name, &song.artist), song.id.clone())
+        } else {
+            let (url, title, channel) = resolve_url(&song.id, cfg).await?;
+            let display = format_title(&title, &channel);
+            {
+                let mut state = player_state().lock().unwrap();
+                let idx = state.current_index;
+                state.queue[idx].name = title;
+                state.queue[idx].artist = channel;
+                state.queue[idx].resolved_url = Some(url.clone());
+            }
+            (url, display, song.id.clone())
+        }
     } else {
         let (_, _, url) = fetch_song(&song.id, cfg).await?;
         (url, format_title(&song.name, &song.artist), song.id.clone())
@@ -447,8 +464,20 @@ async fn previous(cfg: &MusicNcmApiConfig) -> Result<Value> {
     };
 
     let (audio_url, display_title, song_id) = if song.is_url {
-        let (url, title, channel) = resolve_url(&song.id, cfg).await?;
-        (url, format_title(&title, &channel), song.id.clone())
+        if let Some(cached) = &song.resolved_url {
+            (cached.clone(), format_title(&song.name, &song.artist), song.id.clone())
+        } else {
+            let (url, title, channel) = resolve_url(&song.id, cfg).await?;
+            let display = format_title(&title, &channel);
+            {
+                let mut state = player_state().lock().unwrap();
+                let idx = state.current_index;
+                state.queue[idx].name = title;
+                state.queue[idx].artist = channel;
+                state.queue[idx].resolved_url = Some(url.clone());
+            }
+            (url, display, song.id.clone())
+        }
     } else {
         let (_, _, url) = fetch_song(&song.id, cfg).await?;
         (url, format_title(&song.name, &song.artist), song.id.clone())
@@ -631,7 +660,7 @@ fn format_title(name: &str, artist: &str) -> String {
 /// 通过 yt-dlp 解析视频链接，返回 (音频直链, 标题, 频道名)
 async fn resolve_url(url: &str, cfg: &MusicNcmApiConfig) -> Result<(String, String, String)> {
     let yt = &cfg.yt_dlp_path;
-    let resolve_timeout = Duration::from_secs(60);
+    let resolve_timeout = Duration::from_secs(20);
 
     // 获取音频直链
     let url_output = timeout(
@@ -641,7 +670,7 @@ async fn resolve_url(url: &str, cfg: &MusicNcmApiConfig) -> Result<(String, Stri
             .output(),
     )
     .await
-    .map_err(|_| anyhow::anyhow!("yt-dlp 解析超时 (60s)"))?
+    .map_err(|_| anyhow::anyhow!("yt-dlp 解析超时 (20s)"))?
     .map_err(|e| anyhow::anyhow!("yt-dlp 执行失败: {}。请确保 yt-dlp 已安装", e))?;
 
     if !url_output.status.success() {
@@ -664,7 +693,7 @@ async fn resolve_url(url: &str, cfg: &MusicNcmApiConfig) -> Result<(String, Stri
             .output(),
     )
     .await
-    .map_err(|_| anyhow::anyhow!("yt-dlp 元数据解析超时 (60s)"))?
+    .map_err(|_| anyhow::anyhow!("yt-dlp 元数据解析超时 (20s)"))?
     .map_err(|e| anyhow::anyhow!("yt-dlp 执行失败: {}", e))?;
 
     if !meta_output.status.success() {

--- a/src/skills/music/ncm_api.rs
+++ b/src/skills/music/ncm_api.rs
@@ -5,6 +5,7 @@ use ncm_api_rs::{create_client, Query};
 use rand::Rng;
 use serde_json::Value;
 use std::sync::{Mutex, OnceLock};
+use tokio::time::{timeout, Duration};
 use tracing::{info, warn};
 
 // ── 全局状态 ──────────────────────────────────────────────────
@@ -14,6 +15,7 @@ struct SongInfo {
     id: String,
     name: String,
     artist: String,
+    is_url: bool,
 }
 
 /// 播放模式（对齐 ts3audiobot）
@@ -89,6 +91,8 @@ pub(crate) async fn execute(action: &str, args: &Value, cfg: &MusicNcmApiConfig)
     match action {
         "search" => search(args, cfg).await,
         "play" => play(args, cfg).await,
+        "play_url" => play_url(args, cfg).await,
+        "queue_url" => queue_url(args, cfg).await,
         "queue_netease" => queue_netease(args, cfg).await,
         "next" => next(cfg).await,
         "previous" => previous(cfg).await,
@@ -188,6 +192,93 @@ async fn play(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
     Ok(result)
 }
 
+// ── play_url ──────────────────────────────────────────────────
+
+async fn play_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
+    let url = args["url"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Missing url"))?;
+
+    let (audio_url, title, channel) = resolve_url(url, cfg).await?;
+    let display_title = format_title(&title, &channel);
+
+    // Add to queue for navigation
+    {
+        let mut state = player_state().lock().unwrap();
+        state.queue.push(SongInfo {
+            id: url.to_string(),
+            name: title.clone(),
+            artist: channel.clone(),
+            is_url: true,
+        });
+        state.current_index = state.queue.len() - 1;
+    }
+
+    let mut result = serde_json::json!({
+        "status": "playing",
+        "source": url,
+        "title": display_title,
+    });
+    result[PLAY_URL_KEY] = serde_json::Value::String(audio_url);
+    result[PLAY_TITLE_KEY] = serde_json::Value::String(display_title);
+    Ok(result)
+}
+
+// ── queue_url ─────────────────────────────────────────────────
+
+async fn queue_url(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
+    let url = args["url"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Missing url"))?;
+    let play_now = args["play_now"].as_bool().unwrap_or(false);
+
+    let song_info = SongInfo {
+        id: url.to_string(),
+        name: String::new(),
+        artist: String::new(),
+        is_url: true,
+    };
+
+    let insert_index = {
+        let mut state = player_state().lock().unwrap();
+        let idx = state.queue.len();
+        state.queue.push(song_info);
+        if play_now {
+            state.current_index = idx;
+        }
+        idx
+    };
+
+    if play_now {
+        let item = {
+            let state = player_state().lock().unwrap();
+            state.queue[state.current_index].clone()
+        };
+        let (audio_url, title, channel) = resolve_url(&item.id, cfg).await?;
+        let display_title = format_title(&title, &channel);
+        // Update the queue item with resolved info
+        {
+            let mut state = player_state().lock().unwrap();
+            let idx = state.current_index;
+            state.queue[idx].name = title;
+            state.queue[idx].artist = channel;
+        }
+        let mut result = serde_json::json!({
+            "status": "playing",
+            "source": url,
+            "title": display_title,
+        });
+        result[PLAY_URL_KEY] = serde_json::Value::String(audio_url);
+        result[PLAY_TITLE_KEY] = serde_json::Value::String(display_title);
+        return Ok(result);
+    }
+
+    Ok(serde_json::json!({
+        "status": "queued",
+        "queue_position": insert_index,
+    }))
+}
+
 // ── queue_netease ─────────────────────────────────────────────
 
 async fn queue_netease(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
@@ -204,6 +295,7 @@ async fn queue_netease(args: &Value, cfg: &MusicNcmApiConfig) -> Result<Value> {
         id: song_id.to_string(),
         name: title.to_string(),
         artist: artist.to_string(),
+        is_url: false,
     };
 
     // 添加到队列并获取插入位置
@@ -291,15 +383,21 @@ async fn next(cfg: &MusicNcmApiConfig) -> Result<Value> {
         state.queue[state.current_index].clone()
     };
 
-    let (_, _, url) = fetch_song(&song.id, cfg).await?;
-    let title = format_title(&song.name, &song.artist);
+    let (audio_url, display_title, song_id) = if song.is_url {
+        let (url, title, channel) = resolve_url(&song.id, cfg).await?;
+        (url, format_title(&title, &channel), song.id.clone())
+    } else {
+        let (_, _, url) = fetch_song(&song.id, cfg).await?;
+        (url, format_title(&song.name, &song.artist), song.id.clone())
+    };
+
     let mut result = serde_json::json!({
         "status": "playing",
-        "song_id": song.id,
-        "title": title,
+        "song_id": song_id,
+        "title": display_title,
     });
-    result[PLAY_URL_KEY] = serde_json::Value::String(url);
-    result[PLAY_TITLE_KEY] = serde_json::Value::String(title);
+    result[PLAY_URL_KEY] = serde_json::Value::String(audio_url);
+    result[PLAY_TITLE_KEY] = serde_json::Value::String(display_title);
     Ok(result)
 }
 
@@ -351,15 +449,21 @@ async fn previous(cfg: &MusicNcmApiConfig) -> Result<Value> {
         state.queue[state.current_index].clone()
     };
 
-    let (_, _, url) = fetch_song(&song.id, cfg).await?;
-    let title = format_title(&song.name, &song.artist);
+    let (audio_url, display_title, song_id) = if song.is_url {
+        let (url, title, channel) = resolve_url(&song.id, cfg).await?;
+        (url, format_title(&title, &channel), song.id.clone())
+    } else {
+        let (_, _, url) = fetch_song(&song.id, cfg).await?;
+        (url, format_title(&song.name, &song.artist), song.id.clone())
+    };
+
     let mut result = serde_json::json!({
         "status": "playing",
-        "song_id": song.id,
-        "title": title,
+        "song_id": song_id,
+        "title": display_title,
     });
-    result[PLAY_URL_KEY] = serde_json::Value::String(url);
-    result[PLAY_TITLE_KEY] = serde_json::Value::String(title);
+    result[PLAY_URL_KEY] = serde_json::Value::String(audio_url);
+    result[PLAY_TITLE_KEY] = serde_json::Value::String(display_title);
     Ok(result)
 }
 
@@ -525,4 +629,51 @@ fn format_title(name: &str, artist: &str) -> String {
     } else {
         format!("{} - {}", name, artist)
     }
+}
+
+/// 通过 yt-dlp 解析视频链接，返回 (音频直链, 标题, 频道名)
+async fn resolve_url(url: &str, cfg: &MusicNcmApiConfig) -> Result<(String, String, String)> {
+    let yt = &cfg.yt_dlp_path;
+    let resolve_timeout = Duration::from_secs(60);
+
+    // 获取音频直链
+    let url_output = timeout(
+        resolve_timeout,
+        tokio::process::Command::new(yt)
+            .args(["--get-url", "--format", "bestaudio", url])
+            .output(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("yt-dlp 解析超时 (60s)"))?
+    .map_err(|e| anyhow::anyhow!("yt-dlp 执行失败: {}。请确保 yt-dlp 已安装", e))?;
+
+    if !url_output.status.success() {
+        let stderr = String::from_utf8_lossy(&url_output.stderr);
+        return Err(anyhow::anyhow!("yt-dlp 解析失败: {}", stderr.trim()));
+    }
+
+    let audio_url = String::from_utf8(url_output.stdout)
+        .map_err(|_| anyhow::anyhow!("yt-dlp 输出不是有效的 UTF-8"))?
+        .lines()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("yt-dlp 未返回音频链接"))?
+        .to_string();
+
+    // 获取视频元数据（标题和频道名）
+    let meta_output = timeout(
+        resolve_timeout,
+        tokio::process::Command::new(yt)
+            .args(["--print", "title", "--print", "channel", "--skip-download", url])
+            .output(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("yt-dlp 元数据解析超时 (60s)"))?
+    .map_err(|e| anyhow::anyhow!("yt-dlp 执行失败: {}", e))?;
+
+    let meta_stdout = String::from_utf8_lossy(&meta_output.stdout);
+    let mut lines = meta_stdout.lines();
+    let title = lines.next().unwrap_or("Unknown Title").to_string();
+    let channel = lines.next().unwrap_or("Unknown Channel").to_string();
+
+    Ok((audio_url, title, channel))
 }


### PR DESCRIPTION
- Introduce `yt_dlp_path` config option
- Extend music skill description and schema with `play_url` and `queue_url` actions
- Implement URL resolution via yt-dlp, handling playback and queuing
- Update song handling to differentiate between NetEase tracks and video URLs
- Add timeout and error handling for yt-dlp execution

## Summary by Sourcery

在现有网易云音乐播放功能的基础上，新增对来自外部视频 URL 的音频解析与播放支持，该能力由 yt-dlp 配置提供支持。

New Features:
- 引入 `play_url` 和 `queue_url` 动作，用于在音乐技能中播放或加入队列来自视频 URL 的音频。
- 允许配置 `yt-dlp` 可执行文件路径，以便将视频 URL 解析为可播放的音频流。
- 记录队列条目是网易云音乐曲目还是外部 URL，以支持混合播放队列。

Enhancements:
- 扩展音乐技能描述和 JSON 模式，用于说明基于 URL 的播放动作及其参数。
- 更新上一首/下一首处理逻辑，以便能从队列中正确解析并播放网易云歌曲或外部视频 URL。

Documentation:
- 在示例设置文件中记录关于 `yt-dlp` 配置的说明，用于基于 URL 的播放。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for resolving and playing audio from external video URLs alongside existing NetEase music playback, powered by yt-dlp configuration.

New Features:
- Introduce play_url and queue_url actions to play or enqueue audio from video URLs within the music skill.
- Allow configuration of a yt-dlp executable path to resolve video URLs into playable audio streams.
- Track whether queue entries are NetEase tracks or external URLs to support mixed playback queues.

Enhancements:
- Extend the music skill description and JSON schema to describe URL-based playback actions and parameters.
- Update next/previous handling to correctly resolve and play either NetEase songs or external video URLs from the queue.

Documentation:
- Document yt-dlp configuration in the example settings file for URL-based playback.

</details>

新功能：
- 引入 `play_url` 和 `queue_url` 操作，用于从视频 URL 播放或加入队列音频，与现有的网易云音乐曲目一起使用。
- 允许配置 yt-dlp 可执行文件路径，用于将视频 URL 解析为音频流。

增强：
- 扩展音乐技能说明和 JSON 模式，以记录基于 URL 的播放操作及其参数。
- 跟踪队列中的条目是网易云音乐曲目还是外部 URL，以便在混合队列中正确处理上一首/下一首播放。

文档：
- 更新示例配置，记录用于 URL 播放的 yt-dlp 路径设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有网易云音乐播放功能的基础上，新增对来自外部视频 URL 的音频解析与播放支持，该能力由 yt-dlp 配置提供支持。

New Features:
- 引入 `play_url` 和 `queue_url` 动作，用于在音乐技能中播放或加入队列来自视频 URL 的音频。
- 允许配置 `yt-dlp` 可执行文件路径，以便将视频 URL 解析为可播放的音频流。
- 记录队列条目是网易云音乐曲目还是外部 URL，以支持混合播放队列。

Enhancements:
- 扩展音乐技能描述和 JSON 模式，用于说明基于 URL 的播放动作及其参数。
- 更新上一首/下一首处理逻辑，以便能从队列中正确解析并播放网易云歌曲或外部视频 URL。

Documentation:
- 在示例设置文件中记录关于 `yt-dlp` 配置的说明，用于基于 URL 的播放。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for resolving and playing audio from external video URLs alongside existing NetEase music playback, powered by yt-dlp configuration.

New Features:
- Introduce play_url and queue_url actions to play or enqueue audio from video URLs within the music skill.
- Allow configuration of a yt-dlp executable path to resolve video URLs into playable audio streams.
- Track whether queue entries are NetEase tracks or external URLs to support mixed playback queues.

Enhancements:
- Extend the music skill description and JSON schema to describe URL-based playback actions and parameters.
- Update next/previous handling to correctly resolve and play either NetEase songs or external video URLs from the queue.

Documentation:
- Document yt-dlp configuration in the example settings file for URL-based playback.

</details>

</details>