### PR TITLE
refactor: fix message building and add semaphore

### DIFF
--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -16,8 +16,6 @@ model = "gpt-4o"
 omni_model = false    # 多模态模型：true 时自动禁用 TTS/STT，直接使用语音输入输出
 max_context_turns = 3  # 最大上下文对话轮数（0 表示禁用上下文）
 max_context_sessions = 3  # 最大不同用户会话数（超过时淘汰最旧会话）
-max_concurrent_requests = 4     # 最大并发 LLM 请求数
-
 # Headless 语音服务配置
 [headless]
 server_address = "127.0.0.1"

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -14,17 +14,10 @@ pub struct LlmConfig {
     /// 最大会话数（0 表示不限制）
     #[serde(default = "default_max_context_sessions")]
     pub max_context_sessions: usize,
-    /// 最大并发 LLM 请求数
-    #[serde(default = "default_max_concurrent_requests")]
-    pub max_concurrent_requests: u32,
 }
 
 fn default_max_context_sessions() -> usize {
     1000
-}
-
-fn default_max_concurrent_requests() -> u32 {
-    4
 }
 
 impl Default for LlmConfig {
@@ -36,7 +29,6 @@ impl Default for LlmConfig {
             omni_model: false,
             max_context_turns: 0,
             max_context_sessions: 1000,
-            max_concurrent_requests: 4,
         }
     }
 }

--- a/src/llm/engine.rs
+++ b/src/llm/engine.rs
@@ -31,13 +31,12 @@ impl LlmEngine {
         run_tool_loop(messages, tools, self.provider.as_ref(), executor, callbacks).await
     }
 
-    /// 构建带历史上下文的 messages
-    pub fn build_messages(
+    /// 构建系统提示 + 可选的上下文历史（不含最后一条用户消息）
+    fn build_context_base(
         &self,
         source: &SessionSource,
         system_prompt: &str,
         user_ctx: &str,
-        user_msg: &str,
     ) -> Vec<Value> {
         let system_content = format!("{system_prompt}\n\n{user_ctx}");
         let mut messages = vec![json!({"role": "system", "content": system_content})];
@@ -50,8 +49,32 @@ impl LlmEngine {
             }
         }
 
-        messages.push(json!({"role": "user", "content": user_msg}));
+        messages
+    }
 
+    /// 构建带历史上下文的 messages
+    pub fn build_messages(
+        &self,
+        source: &SessionSource,
+        system_prompt: &str,
+        user_ctx: &str,
+        user_msg: &str,
+    ) -> Vec<Value> {
+        let mut messages = self.build_context_base(source, system_prompt, user_ctx);
+        messages.push(json!({"role": "user", "content": user_msg}));
+        messages
+    }
+
+    /// 构建带历史上下文的 omni messages（用户消息为 audio content）
+    pub fn build_omni_messages(
+        &self,
+        source: &SessionSource,
+        system_prompt: &str,
+        user_ctx: &str,
+        user_content: Vec<Value>,
+    ) -> Vec<Value> {
+        let mut messages = self.build_context_base(source, system_prompt, user_ctx);
+        messages.push(json!({"role": "user", "content": user_content}));
         messages
     }
 

--- a/src/router/nc_router.rs
+++ b/src/router/nc_router.rs
@@ -15,7 +15,6 @@ use crate::skills::{NcExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use anyhow::Result;
 use dashmap::DashMap;
 use std::sync::Arc;
-use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 struct NcExecutor<'a> {
@@ -41,7 +40,6 @@ pub struct NcRouter {
     gate: Arc<PermissionGate>,
     llm: Arc<LlmEngine>,
     registry: Arc<SkillRegistry>,
-    semaphore: Arc<Semaphore>,
     ts_adapter: Option<Arc<TsAdapter>>,
     ts_clients: Option<Arc<DashMap<u32, ClientInfo>>>,
 }
@@ -87,7 +85,6 @@ impl NcRouter {
         ts_adapter: Option<Arc<TsAdapter>>,
         ts_clients: Option<Arc<DashMap<u32, ClientInfo>>>,
     ) -> Self {
-        let max_concurrent = config.llm.max_concurrent_requests;
         Self {
             config,
             prompts,
@@ -95,7 +92,6 @@ impl NcRouter {
             gate,
             llm,
             registry,
-            semaphore: Arc::new(Semaphore::new(max_concurrent as usize)),
             ts_adapter,
             ts_clients,
         }
@@ -149,18 +145,10 @@ impl NcRouter {
         let gate = self.gate.clone();
         let llm = self.llm.clone();
         let registry = self.registry.clone();
-        let semaphore = self.semaphore.clone();
         let ts_adapter = self.ts_adapter.clone();
         let ts_clients = self.ts_clients.clone();
 
         tokio::spawn(async move {
-            let _permit = match semaphore.acquire().await {
-                Ok(p) => p,
-                Err(e) => {
-                    error!("NcRouter semaphore error: {e}");
-                    return;
-                }
-            };
             let router = NcRouter {
                 config,
                 prompts,
@@ -168,7 +156,6 @@ impl NcRouter {
                 gate,
                 llm,
                 registry,
-                semaphore: Arc::new(Semaphore::new(1)),
                 ts_adapter,
                 ts_clients,
             };
@@ -183,18 +170,10 @@ impl NcRouter {
         let gate = self.gate.clone();
         let llm = self.llm.clone();
         let registry = self.registry.clone();
-        let semaphore = self.semaphore.clone();
         let ts_adapter = self.ts_adapter.clone();
         let ts_clients = self.ts_clients.clone();
 
         tokio::spawn(async move {
-            let _permit = match semaphore.acquire().await {
-                Ok(p) => p,
-                Err(e) => {
-                    error!("NcRouter semaphore error: {e}");
-                    return;
-                }
-            };
             let router = NcRouter {
                 config,
                 prompts,
@@ -202,7 +181,6 @@ impl NcRouter {
                 gate,
                 llm,
                 registry,
-                semaphore: Arc::new(Semaphore::new(1)),
                 ts_adapter,
                 ts_clients,
             };
@@ -359,7 +337,8 @@ impl NcRouter {
                     );
                     val.to_string()
                 }
-                Err(_unified_err) => {
+                Err(unified_err) => {
+                    debug!(skill = %call.name, error = %unified_err, "Falling back to NC execution");
                     let nc_ctx = NcExecutionContext {
                         adapter: self.adapter.clone(),
                         caller_id: user_id,

--- a/src/router/ts_router.rs
+++ b/src/router/ts_router.rs
@@ -10,7 +10,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::sync::Arc;
-use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone)]
@@ -47,7 +46,6 @@ pub struct EventRouter {
     gate: Arc<PermissionGate>,
     llm: Arc<LlmEngine>,
     registry: Arc<SkillRegistry>,
-    semaphore: Arc<Semaphore>,
     nc_adapter: Option<Arc<NapCatAdapter>>,
 }
 
@@ -62,7 +60,6 @@ impl EventRouter {
         clients: Arc<DashMap<u32, ClientInfo>>,
         nc_adapter: Option<Arc<NapCatAdapter>>,
     ) -> Self {
-        let max_concurrent = config.llm.max_concurrent_requests;
         Self {
             config,
             prompts,
@@ -71,7 +68,6 @@ impl EventRouter {
             gate,
             llm,
             registry,
-            semaphore: Arc::new(Semaphore::new(max_concurrent as usize)),
             nc_adapter,
         }
     }
@@ -117,17 +113,9 @@ impl EventRouter {
                     let gate = self.gate.clone();
                     let llm = self.llm.clone();
                     let registry = self.registry.clone();
-                    let semaphore = self.semaphore.clone();
                     let nc_adapter = self.nc_adapter.clone();
 
                     tokio::spawn(async move {
-                        let _permit = match semaphore.acquire().await {
-                            Ok(p) => p,
-                            Err(e) => {
-                                error!("Failed to acquire semaphore: {}", e);
-                                return;
-                            }
-                        };
                         let router = Self::new_with_clients(
                             config, prompts, adapter, gate, llm, registry, clients, nc_adapter,
                         );
@@ -228,7 +216,16 @@ impl EventRouter {
     }
 
     async fn handle_message(&self, event: TextMessageEvent) {
-        if event.invoker_id == self.adapter.get_bot_clid() || event.invoker_name == "TS3AudioBot" {
+        if event.invoker_id == self.adapter.get_bot_clid() {
+            return;
+        }
+        let musicbot_name = &self.config.music_backend.musicbot_name;
+        if !musicbot_name.is_empty()
+            && event
+                .invoker_name
+                .to_ascii_lowercase()
+                .contains(&musicbot_name.to_ascii_lowercase())
+        {
             return;
         }
 

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -6,7 +6,7 @@ use futures_util::StreamExt;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
 use tracing::{debug, error, info, warn};
@@ -55,6 +55,7 @@ pub struct VoiceRouter {
     registry: Arc<SkillRegistry>,
     ts_adapter: Arc<TsAdapter>,
     ts_clients: Arc<DashMap<u32, ClientInfo>>,
+    semaphore: Arc<Semaphore>,
     audio_pipeline: Mutex<Option<OpusSttPipeline>>,
     speech_provider: Option<Arc<OpenAiSpeechProvider>>,
 }
@@ -78,8 +79,10 @@ impl VoiceRouter {
             OpenAiSpeechProvider::new(config.clone(), prompts.tts.style_prompt.clone())
                 .ok()
                 .map(Arc::new);
+        let max_concurrent = config.llm.max_concurrent_requests;
         let need_audio_pipeline = config.headless.stt.enabled || config.llm.omni_model;
         Self {
+            semaphore: Arc::new(Semaphore::new(max_concurrent as usize)),
             audio_pipeline: Mutex::new(need_audio_pipeline.then(OpusSttPipeline::new)),
             config,
             prompts,
@@ -256,6 +259,13 @@ impl VoiceRouter {
         let Some(clean_text) = preprocess_text_message(&chat.message) else {
             return Ok(());
         };
+        let _permit = match self.semaphore.acquire().await {
+            Ok(p) => p,
+            Err(e) => {
+                error!("VoiceRouter semaphore error: {e}");
+                return Ok(());
+            }
+        };
         self.handle_user_input(client, ctx, clean_text).await
     }
 
@@ -264,6 +274,13 @@ impl VoiceRouter {
         client: &mut VoiceServiceClient<Channel>,
         audio: voicev1::AudioFrameEvent,
     ) -> Result<()> {
+        let _permit = match self.semaphore.acquire().await {
+            Ok(p) => p,
+            Err(e) => {
+                error!("VoiceRouter semaphore error: {e}");
+                return Ok(());
+            }
+        };
         let bot_clid = self.ts_adapter.get_bot_clid();
         if bot_clid != 0 && audio.from_client_id == bot_clid {
             return Ok(());
@@ -337,7 +354,7 @@ impl VoiceRouter {
         ctx.caller_name = chunk.speaker_name;
         ctx.caller_id = chunk.speaker_client_id;
 
-        let (mut messages, tools) = self.build_omni_llm_request(&ctx, audio_data);
+        let (mut messages, tools, session_source) = self.build_omni_llm_request(&ctx, audio_data);
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
@@ -357,6 +374,8 @@ impl VoiceRouter {
                 if !result.content.is_empty() {
                     info!("[TS&TTS] LLM final reply: {}", &result.content);
                     self.send_reply(client, &ctx, &result.content).await?;
+                    self.llm
+                        .save_turn(&session_source, "[音频消息]".into(), result.content);
                 }
             }
             Err(e) => return Err(e.into()),
@@ -569,14 +588,20 @@ impl VoiceRouter {
         &self,
         ctx: &CallerContext,
         audio_data: String,
-    ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+    ) -> (
+        Vec<serde_json::Value>,
+        Vec<serde_json::Value>,
+        SessionSource,
+    ) {
         let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx);
+        let source = SessionSource::Headless {
+            caller_id: ctx.caller_id,
+        };
         let content = vec![json!({ "type": "input_audio", "input_audio": { "data": audio_data } })];
-        let messages = vec![
-            json!({"role": "system", "content": format!("{system_prompt}\n\n{user_ctx}")}),
-            json!({"role": "user", "content": content}),
-        ];
-        (messages, tools)
+        let messages = self
+            .llm
+            .build_omni_messages(&source, &system_prompt, &user_ctx, content);
+        (messages, tools, source)
     }
 
     async fn send_reply(

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -6,7 +6,7 @@ use futures_util::StreamExt;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, Mutex, Semaphore};
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
 use tracing::{debug, error, info, warn};
@@ -55,7 +55,6 @@ pub struct VoiceRouter {
     registry: Arc<SkillRegistry>,
     ts_adapter: Arc<TsAdapter>,
     ts_clients: Arc<DashMap<u32, ClientInfo>>,
-    semaphore: Arc<Semaphore>,
     audio_pipeline: Mutex<Option<OpusSttPipeline>>,
     speech_provider: Option<Arc<OpenAiSpeechProvider>>,
 }
@@ -79,10 +78,8 @@ impl VoiceRouter {
             OpenAiSpeechProvider::new(config.clone(), prompts.tts.style_prompt.clone())
                 .ok()
                 .map(Arc::new);
-        let max_concurrent = config.llm.max_concurrent_requests;
         let need_audio_pipeline = config.headless.stt.enabled || config.llm.omni_model;
         Self {
-            semaphore: Arc::new(Semaphore::new(max_concurrent as usize)),
             audio_pipeline: Mutex::new(need_audio_pipeline.then(OpusSttPipeline::new)),
             config,
             prompts,
@@ -157,7 +154,7 @@ impl VoiceRouter {
                 return CallerContext {
                     caller_id: c.clid,
                     caller_name: chat.invoker_name.clone(),
-                    caller_uid: chat.invoker_unique_id.clone(),
+                    caller_uid: c.clid.to_string(),
                     groups: c.server_groups.clone(),
                     channel_group_id: c.channel_group_id,
                     reply_target_mode: chat.reply_target_mode,
@@ -168,7 +165,7 @@ impl VoiceRouter {
         CallerContext {
             caller_id: 0,
             caller_name: chat.invoker_name.clone(),
-            caller_uid: chat.invoker_unique_id.clone(),
+            caller_uid: 0.to_string(),
             groups: vec![],
             channel_group_id: 0,
             reply_target_mode: chat.reply_target_mode,
@@ -192,7 +189,7 @@ impl VoiceRouter {
             return CallerContext {
                 caller_id: c.clid,
                 caller_name: c.nickname.clone(),
-                caller_uid: c.cldbid.to_string(),
+                caller_uid: c.clid.to_string(),
                 groups: c.server_groups.clone(),
                 channel_group_id: c.channel_group_id,
                 reply_target_mode,
@@ -236,13 +233,25 @@ impl VoiceRouter {
                 None,
             );
             let args = call.arguments.clone();
-            match skill.execute_unified(args.clone(), &unified_ctx).await {
-                Ok(v) => Ok(v),
-                Err(_) => skill.execute(args, &exec_ctx).await,
+            let result = match skill.execute_unified(args.clone(), &unified_ctx).await {
+                Ok(val) => {
+                    info!(skill = %call.name, caller = %ctx.caller_name, "Voice unified skill executed successfully");
+                    Ok(val)
+                }
+                Err(unified_err) => {
+                    debug!(skill = %call.name, error = %unified_err, "Falling back to TS execution");
+                    skill.execute(args, &exec_ctx).await
+                }
+            };
+            match result {
+                Ok(val) => val.to_string(),
+                Err(e) => {
+                    error!(skill = %call.name, error = %e, "Skill execution failed");
+                    format!("技能执行失败: {}", e)
+                }
             }
-            .map(|v| v.to_string())
-            .unwrap_or_else(|e| format!("技能执行失败: {}", e))
         } else {
+            warn!(caller = %ctx.caller_name, skill = %call.name, "Skill not found");
             "未找到指定的技能".to_string()
         }
     }
@@ -259,13 +268,6 @@ impl VoiceRouter {
         let Some(clean_text) = preprocess_text_message(&chat.message) else {
             return Ok(());
         };
-        let _permit = match self.semaphore.acquire().await {
-            Ok(p) => p,
-            Err(e) => {
-                error!("VoiceRouter semaphore error: {e}");
-                return Ok(());
-            }
-        };
         self.handle_user_input(client, ctx, clean_text).await
     }
 
@@ -274,13 +276,6 @@ impl VoiceRouter {
         client: &mut VoiceServiceClient<Channel>,
         audio: voicev1::AudioFrameEvent,
     ) -> Result<()> {
-        let _permit = match self.semaphore.acquire().await {
-            Ok(p) => p,
-            Err(e) => {
-                error!("VoiceRouter semaphore error: {e}");
-                return Ok(());
-            }
-        };
         let bot_clid = self.ts_adapter.get_bot_clid();
         if bot_clid != 0 && audio.from_client_id == bot_clid {
             return Ok(());
@@ -378,7 +373,16 @@ impl VoiceRouter {
                         .save_turn(&session_source, "[音频消息]".into(), result.content);
                 }
             }
-            Err(e) => return Err(e.into()),
+            Err(e) => {
+                if let Some(ref cb) = callbacks {
+                    if let Some(ref on_end) = cb.on_turn_end {
+                        on_end("stop");
+                    }
+                }
+                self.send_reply(client, &ctx, "AI 后端当前不可用。请稍后再试。")
+                    .await?;
+                return Err(e.into());
+            }
         };
         Ok(())
     }


### PR DESCRIPTION
- Introduce build_context_base and build_omni_messages; add Semaphore

## Summary by Sourcery

使用信号量限制并发语音 LLM 处理，并复用共享的上下文构建逻辑以同时支持文本和 omni（音频）LLM 请求。

New Features:
- 在语音路由中添加一个信号量，根据配置限制与 LLM 相关的并发请求处理数量。
- 在 LLM 引擎中引入 omni 风格的消息构造方式，在共享与文本请求相同的基础上下文构建逻辑的同时，支持音频内容。

Enhancements:
- 将 LLM 消息构造重构为可复用的基础上下文构建器，由标准消息构造器和 omni 消息构造器共同使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit concurrent voice LLM handling with a semaphore and reuse shared context-building logic for both text and omni (audio) LLM requests.

New Features:
- Add a semaphore to the voice router to cap concurrent LLM-related request handling based on configuration.
- Introduce omni-style message construction in the LLM engine that supports audio content while sharing base context-building logic with text requests.

Enhancements:
- Refactor LLM message construction into a reusable base context builder used by both standard and omni message builders.

</details>