### PR TITLE
fix: onlinelist

### DIFF
--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -16,6 +16,7 @@ model = "gpt-4o"
 omni_model = false    # 多模态模型：true 时自动禁用 TTS/STT，直接使用语音输入输出
 max_context_turns = 3  # 最大上下文对话轮数（0 表示禁用上下文）
 max_context_sessions = 3  # 最大不同用户会话数（超过时淘汰最旧会话）
+
 # Headless 语音服务配置
 [headless]
 server_address = "127.0.0.1"

--- a/src/adapter/headless/event.rs
+++ b/src/adapter/headless/event.rs
@@ -164,22 +164,13 @@ impl TsAdapter {
             let tx = tx.clone();
             client.on_client_enter(Arc::new(move |event: tsclient_rs::Event| {
                 if let tsclient_rs::Event::ClientEnter(ref info) = event {
-                    let groups: Vec<u32> = info
-                        .server_groups
-                        .iter()
-                        .filter_map(|g| g.parse().ok())
-                        .collect();
                     let _ = tx.send(TsEvent::ClientEnterView(ClientEnterEvent {
                         clid: info.id as u32,
-                        cldbid: 0,
                         client_nickname: info.nickname.clone(),
-                        client_server_groups: groups,
-                        client_channel_group_id: 0,
-                        channel_id: info.channel_id as u32,
                     }));
                     debug!(
-                        "Client entered view: clid={}, nickname={}, channel_id={}",
-                        info.id, info.nickname, info.channel_id
+                        "Client entered view: clid={}, nickname={}",
+                        info.id, info.nickname
                     );
                 }
             }));
@@ -317,28 +308,6 @@ impl TsAdapter {
             .map_err(|e| anyhow!("getClientInfo failed: {e}"))
     }
 
-    pub async fn fetch_client_snapshot(&self) -> Result<Vec<ClientEnterEvent>> {
-        let clients = self.list_clients().await?;
-        Ok(clients
-            .into_iter()
-            .map(|c| {
-                let groups: Vec<u32> = c
-                    .server_groups
-                    .iter()
-                    .filter_map(|g| g.parse().ok())
-                    .collect();
-                ClientEnterEvent {
-                    clid: c.id as u32,
-                    cldbid: 0,
-                    client_nickname: c.nickname,
-                    client_server_groups: groups,
-                    client_channel_group_id: 0,
-                    channel_id: c.channel_id as u32,
-                }
-            })
-            .collect())
-    }
-
     pub async fn quit(&self) -> Result<()> {
         self.client
             .disconnect()
@@ -374,11 +343,7 @@ pub enum TextMessageTarget {
 #[derive(Debug, Clone)]
 pub struct ClientEnterEvent {
     pub clid: u32,
-    pub cldbid: u32,
     pub client_nickname: String,
-    pub client_server_groups: Vec<u32>,
-    pub client_channel_group_id: u32,
-    pub channel_id: u32,
 }
 
 #[derive(Debug, Clone)]

--- a/src/adapter/headless/event.rs
+++ b/src/adapter/headless/event.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use tokio::sync::broadcast;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use crate::config::AppConfig;
 
@@ -100,7 +100,6 @@ impl TsAdapter {
                         if let Ok(cid_u64) = cid.parse::<u64>() {
                             let pw = &hc.channel_password;
                             let clid = client.client_id();
-                            info!(cid = cid_u64, "joining channel on startup");
                             if let Err(e) = tsclient_rs::clientMove(&client, clid, cid_u64, pw).await
                             {
                                 warn!("join channel failed: {e}");
@@ -160,32 +159,7 @@ impl TsAdapter {
             }));
         }
 
-        {
-            let tx = tx.clone();
-            client.on_client_enter(Arc::new(move |event: tsclient_rs::Event| {
-                if let tsclient_rs::Event::ClientEnter(ref info) = event {
-                    let _ = tx.send(TsEvent::ClientEnterView(ClientEnterEvent {
-                        clid: info.id as u32,
-                        client_nickname: info.nickname.clone(),
-                    }));
-                    debug!(
-                        "Client entered view: clid={}, nickname={}",
-                        info.id, info.nickname
-                    );
-                }
-            }));
-        }
 
-        {
-            let tx = tx.clone();
-            client.on_client_leave(Arc::new(move |event: tsclient_rs::Event| {
-                if let tsclient_rs::Event::ClientLeave(ref ev) = event {
-                    let _ = tx.send(TsEvent::ClientLeftView(ClientLeftEvent {
-                        clid: ev.id as u32,
-                    }));
-                }
-            }));
-        }
     }
 
     async fn upgrade_identity_and_save(
@@ -319,8 +293,6 @@ impl TsAdapter {
 #[derive(Debug, Clone)]
 pub enum TsEvent {
     TextMessage(TextMessageEvent),
-    ClientEnterView(ClientEnterEvent),
-    ClientLeftView(ClientLeftEvent),
 }
 
 #[derive(Debug, Clone)]
@@ -340,13 +312,4 @@ pub enum TextMessageTarget {
     Server,
 }
 
-#[derive(Debug, Clone)]
-pub struct ClientEnterEvent {
-    pub clid: u32,
-    pub client_nickname: String,
-}
 
-#[derive(Debug, Clone)]
-pub struct ClientLeftEvent {
-    pub clid: u32,
-}

--- a/src/adapter/headless/mod.rs
+++ b/src/adapter/headless/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use dashmap::DashMap;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -11,7 +10,6 @@ use tracing::{error, info};
 use crate::config::{AppConfig, PromptsConfig};
 use crate::llm::LlmEngine;
 use crate::permission::PermissionGate;
-use crate::router::ClientInfo;
 use crate::skills::SkillRegistry;
 
 pub mod tsbot {
@@ -133,7 +131,6 @@ impl Runtime {
         llm: Arc<LlmEngine>,
         registry: Arc<SkillRegistry>,
         ts_adapter: Arc<crate::adapter::TsAdapter>,
-        ts_clients: Arc<DashMap<u32, ClientInfo>>,
     ) -> Self {
         let voice_enabled = config.headless.stt.enabled || config.headless.tts.enabled;
         if !voice_enabled {
@@ -166,7 +163,6 @@ impl Runtime {
         let bridge_llm = llm.clone();
         let bridge_registry = registry.clone();
         let bridge_ts_adapter = ts_adapter.clone();
-        let bridge_ts_clients = ts_clients.clone();
         let shutdown_for_bridge = shutdown.clone();
         let bridge_handle = Some(tokio::spawn(async move {
             loop {
@@ -181,7 +177,6 @@ impl Runtime {
                         bridge_llm.clone(),
                         bridge_registry.clone(),
                         bridge_ts_adapter.clone(),
-                        bridge_ts_clients.clone(),
                     ).run() => {
                         if let Err(e) = run_result {
                             error!("voice router failed: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use crate::{
     adapter::TsAdapter, config::AppConfig, llm::LlmEngine, permission::PermissionGate,
     router::EventRouter,
 };
-use dashmap::DashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -47,7 +46,6 @@ async fn main() -> Result<()> {
     let adapter = TsAdapter::connect(config.clone(), identity_file).await?;
 
     let nc_adapter = adapter::napcat::connect_if_enabled(config.clone()).await?;
-    let clients = Arc::new(DashMap::new());
 
     let ts_router = EventRouter::new_with_clients(
         config.clone(),
@@ -56,7 +54,6 @@ async fn main() -> Result<()> {
         gate.clone(),
         llm.clone(),
         registry.clone(),
-        clients.clone(),
         nc_adapter.clone(),
     );
 
@@ -67,7 +64,6 @@ async fn main() -> Result<()> {
         llm.clone(),
         registry.clone(),
         adapter.clone(),
-        clients,
     );
 
     let result = router::run_routers(

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -4,7 +4,7 @@ mod unified;
 mod voice_router;
 
 pub use nc_router::NcRouter;
-pub use ts_router::{ClientInfo, EventRouter};
+pub use ts_router::EventRouter;
 pub use unified::{ReplyPolicy, UnifiedInboundEvent};
 pub use voice_router::VoiceRouter;
 
@@ -42,7 +42,6 @@ pub async fn run_routers(
             llm,
             registry,
             Some(adapter),
-            Some(ts_router.clients.clone()),
         );
         let nc_future = tokio::spawn(async move { nc_router.run().await });
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -34,6 +34,16 @@ pub async fn run_routers(
 
     if let Some(nc_adapter) = nc_adapter {
         let bot_clid = adapter.get_bot_clid();
+        let bot_ctx = match adapter.list_clients().await {
+            Ok(clients) => {
+                if let Some(bot) = clients.iter().find(|c| c.id as u32 == bot_clid) {
+                    format!("Bot ready: {}({})[{}]. Listening for TS + NapCat events.", bot.nickname, bot.id, bot.channel_id)
+                } else {
+                    format!("Bot ready (clid={}). Listening for TS + NapCat events.", bot_clid)
+                }
+            }
+            Err(_) => format!("Bot ready (clid={}). Listening for TS + NapCat events.", bot_clid),
+        };
         let nc_router = NcRouter::new_with_ts(
             config,
             prompts,
@@ -45,10 +55,7 @@ pub async fn run_routers(
         );
         let nc_future = tokio::spawn(async move { nc_router.run().await });
 
-        info!(
-            "Bot ready (clid={}). Listening for TS + NapCat events.",
-            bot_clid
-        );
+        info!("{bot_ctx}");
 
         tokio::select! {
             res = ts_router.run() => map_ts_router_result(res),
@@ -62,10 +69,18 @@ pub async fn run_routers(
         }
     } else {
         info!("NapCat adapter disabled, running in TeamSpeak-only mode");
-        info!(
-            "Bot ready (clid={}). Listening for TeamSpeak events.",
-            adapter.get_bot_clid()
-        );
+        let bot_clid = adapter.get_bot_clid();
+        let bot_ctx = match adapter.list_clients().await {
+            Ok(clients) => {
+                if let Some(bot) = clients.iter().find(|c| c.id as u32 == bot_clid) {
+                    format!("Bot ready: {}({})[{}]. Listening for TeamSpeak events.", bot.nickname, bot.id, bot.channel_id)
+                } else {
+                    format!("Bot ready (clid={}). Listening for TeamSpeak events.", bot_clid)
+                }
+            }
+            Err(_) => format!("Bot ready (clid={}). Listening for TeamSpeak events.", bot_clid),
+        };
+        info!("{bot_ctx}");
 
         tokio::select! {
             res = ts_router.run() => map_ts_router_result(res),

--- a/src/router/nc_router.rs
+++ b/src/router/nc_router.rs
@@ -13,6 +13,7 @@ use crate::permission::PermissionGate;
 use crate::router::{ReplyPolicy, UnifiedInboundEvent};
 use crate::skills::{NcExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use anyhow::Result;
+use serde_json::json;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
@@ -376,9 +377,28 @@ impl NcRouter {
         };
 
         let system_prompt = &self.prompts.system.content;
+
+        let online_suffix = if let Some(ref adapter) = self.ts_adapter {
+            match adapter.list_clients().await {
+                Ok(clients) => {
+                    let arr: Vec<serde_json::Value> = clients
+                        .iter()
+                        .map(|c| {
+                            json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id})
+                        })
+                        .collect();
+                    info!("Fetched {} online clients for LLM context", clients.len());
+                    format!("\nOnline: {}", serde_json::to_string(&arr).unwrap_or_default())
+                }
+                Err(_) => String::new(),
+            }
+        } else {
+            String::new()
+        };
+
         let user_ctx = match group_id {
-            Some(gid) => format!("User: {} (QQ: {}, Group: {})", sender_name, user_id, gid),
-            None => format!("User: {} (QQ: {}, Private Chat)", sender_name, user_id),
+            Some(gid) => format!("User: {} (QQ: {}, Group: {}){}", sender_name, user_id, gid, online_suffix),
+            None => format!("User: {} (QQ: {}, Private Chat){}", sender_name, user_id, online_suffix),
         };
 
         let mut messages = self

--- a/src/router/nc_router.rs
+++ b/src/router/nc_router.rs
@@ -10,10 +10,9 @@ use crate::config::{AppConfig, PromptsConfig};
 use crate::llm::context::SessionSource;
 use crate::llm::{LlmEngine, ToolCall, ToolExecutor};
 use crate::permission::PermissionGate;
-use crate::router::{ClientInfo, ReplyPolicy, UnifiedInboundEvent};
+use crate::router::{ReplyPolicy, UnifiedInboundEvent};
 use crate::skills::{NcExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use anyhow::Result;
-use dashmap::DashMap;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
@@ -41,7 +40,6 @@ pub struct NcRouter {
     llm: Arc<LlmEngine>,
     registry: Arc<SkillRegistry>,
     ts_adapter: Option<Arc<TsAdapter>>,
-    ts_clients: Option<Arc<DashMap<u32, ClientInfo>>>,
 }
 
 impl NcRouter {
@@ -83,7 +81,6 @@ impl NcRouter {
         llm: Arc<LlmEngine>,
         registry: Arc<SkillRegistry>,
         ts_adapter: Option<Arc<TsAdapter>>,
-        ts_clients: Option<Arc<DashMap<u32, ClientInfo>>>,
     ) -> Self {
         Self {
             config,
@@ -93,7 +90,6 @@ impl NcRouter {
             llm,
             registry,
             ts_adapter,
-            ts_clients,
         }
     }
 
@@ -146,7 +142,6 @@ impl NcRouter {
         let llm = self.llm.clone();
         let registry = self.registry.clone();
         let ts_adapter = self.ts_adapter.clone();
-        let ts_clients = self.ts_clients.clone();
 
         tokio::spawn(async move {
             let router = NcRouter {
@@ -157,7 +152,6 @@ impl NcRouter {
                 llm,
                 registry,
                 ts_adapter,
-                ts_clients,
             };
             router.handle_private(msg).await;
         });
@@ -171,7 +165,6 @@ impl NcRouter {
         let llm = self.llm.clone();
         let registry = self.registry.clone();
         let ts_adapter = self.ts_adapter.clone();
-        let ts_clients = self.ts_clients.clone();
 
         tokio::spawn(async move {
             let router = NcRouter {
@@ -182,7 +175,6 @@ impl NcRouter {
                 llm,
                 registry,
                 ts_adapter,
-                ts_clients,
             };
             router.handle_group(msg).await;
         });
@@ -317,14 +309,10 @@ impl NcRouter {
                 gate: self.gate.clone(),
                 config: self.config.clone(),
             };
-            let mut unified_ctx = UnifiedExecutionContext::from_nc(&nc_ctx).with_cross_adapters(
+            let unified_ctx = UnifiedExecutionContext::from_nc(&nc_ctx).with_cross_adapters(
                 self.ts_adapter.clone(),
-                self.ts_clients.as_ref().map(|c| c.as_ref()),
                 Some(self.adapter.clone()),
             );
-            if let Some(ref ts_clients) = self.ts_clients {
-                unified_ctx.ts_clients = Some(ts_clients.as_ref());
-            }
 
             let args = call.arguments.clone();
             match skill.execute_unified(args.clone(), &unified_ctx).await {

--- a/src/router/ts_router.rs
+++ b/src/router/ts_router.rs
@@ -63,24 +63,11 @@ impl EventRouter {
     pub async fn run(&self) -> Result<()> {
         let mut rx = self.adapter.subscribe();
 
-        while let Ok(event) = rx.recv().await {
-            match event {
-                TsEvent::TextMessage(msg) => {
-                    let this = self.clone();
-                    tokio::spawn(async move {
-                        this.handle_message(msg).await;
-                    });
-                }
-                TsEvent::ClientEnterView(e) => {
-                    debug!(
-                        "Client entered view: clid={}, nickname={}",
-                        e.clid, e.client_nickname
-                    );
-                }
-                TsEvent::ClientLeftView(e) => {
-                    debug!("Client left view: clid={}", e.clid);
-                }
-            }
+        while let Ok(TsEvent::TextMessage(msg)) = rx.recv().await {
+            let this = self.clone();
+            tokio::spawn(async move {
+                this.handle_message(msg).await;
+            });
         }
         Ok(())
     }
@@ -184,27 +171,32 @@ impl EventRouter {
         };
         let system_prompt = &self.prompts.system.content;
 
-        let online_clients = match self.adapter.list_clients().await {
+        let (online_clients, invoker_channel) = match self.adapter.list_clients().await {
             Ok(clients) => {
-                let arr: Vec<_> = clients
+                let arr: Vec<serde_json::Value> = clients
                     .iter()
                     .map(|c| {
-                        let g: Vec<u32> =
-                            c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
-                        json!({ "clid": c.id, "nickname": c.nickname, "uid": c.uid, "groups": g, "channel_id": c.channel_id })
+                        json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id})
                     })
                     .collect();
-                serde_json::to_string(&arr).unwrap_or_default()
+                let invoker_chan = clients
+                    .iter()
+                    .find(|c| c.id as u32 == event.invoker_id)
+                    .map(|c| c.channel_id)
+                    .unwrap_or(0);
+                info!("Fetched {} online clients for LLM context", clients.len());
+                (serde_json::to_string(&arr).unwrap_or_default(), invoker_chan)
             }
             Err(e) => {
                 warn!("Failed to fetch online clients: {e}");
-                String::new()
+                (String::new(), 0)
             }
         };
 
         let user_ctx = format!(
-            "User: {} (clid: {}, groups: {:?})\nOnline clients: {}",
-            event.invoker_name, event.invoker_id, groups, online_clients
+            r#"invoker: {{"name":"{}","clid":{},"channel_id":{}}}
+Online: {}"#,
+            event.invoker_name, event.invoker_id, invoker_channel, online_clients
         );
 
         let mut messages = self

--- a/src/router/ts_router.rs
+++ b/src/router/ts_router.rs
@@ -8,19 +8,9 @@ use crate::router::{ReplyPolicy, UnifiedInboundEvent};
 use crate::skills::{ExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use anyhow::Result;
 use async_trait::async_trait;
-use dashmap::DashMap;
+use serde_json::json;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
-
-#[derive(Debug, Clone)]
-pub struct ClientInfo {
-    pub clid: u32,
-    pub cldbid: u32,
-    pub nickname: String,
-    pub server_groups: Vec<u32>,
-    pub channel_group_id: u32,
-    pub channel_id: u32,
-}
 
 struct SqExecutor<'a> {
     router: &'a EventRouter,
@@ -38,11 +28,11 @@ impl ToolExecutor for SqExecutor<'_> {
     }
 }
 
+#[derive(Clone)]
 pub struct EventRouter {
     config: Arc<AppConfig>,
     prompts: Arc<PromptsConfig>,
     adapter: Arc<TsAdapter>,
-    pub clients: Arc<DashMap<u32, ClientInfo>>,
     gate: Arc<PermissionGate>,
     llm: Arc<LlmEngine>,
     registry: Arc<SkillRegistry>,
@@ -57,14 +47,12 @@ impl EventRouter {
         gate: Arc<PermissionGate>,
         llm: Arc<LlmEngine>,
         registry: Arc<SkillRegistry>,
-        clients: Arc<DashMap<u32, ClientInfo>>,
         nc_adapter: Option<Arc<NapCatAdapter>>,
     ) -> Self {
         Self {
             config,
             prompts,
             adapter,
-            clients,
             gate,
             llm,
             registry,
@@ -75,51 +63,12 @@ impl EventRouter {
     pub async fn run(&self) -> Result<()> {
         let mut rx = self.adapter.subscribe();
 
-        let snapshot_result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            self.adapter.fetch_client_snapshot(),
-        )
-        .await;
-
-        match snapshot_result {
-            Ok(Ok(snapshot)) => {
-                let snapshot_count = snapshot.len();
-                for client in snapshot {
-                    self.cache_client(
-                        client.clid,
-                        client.cldbid,
-                        client.client_nickname,
-                        client.client_server_groups,
-                        client.client_channel_group_id,
-                        client.channel_id,
-                    );
-                }
-                info!(
-                    "Prewarmed client cache with {} online clients",
-                    snapshot_count
-                );
-            }
-            Ok(Err(err)) => warn!("Failed to prewarm client cache: {err}"),
-            Err(_) => warn!("Timed out while prewarming client cache"),
-        }
-
         while let Ok(event) = rx.recv().await {
             match event {
                 TsEvent::TextMessage(msg) => {
-                    let config = self.config.clone();
-                    let prompts = self.prompts.clone();
-                    let adapter = self.adapter.clone();
-                    let clients = self.clients.clone();
-                    let gate = self.gate.clone();
-                    let llm = self.llm.clone();
-                    let registry = self.registry.clone();
-                    let nc_adapter = self.nc_adapter.clone();
-
+                    let this = self.clone();
                     tokio::spawn(async move {
-                        let router = Self::new_with_clients(
-                            config, prompts, adapter, gate, llm, registry, clients, nc_adapter,
-                        );
-                        router.handle_message(msg).await;
+                        this.handle_message(msg).await;
                     });
                 }
                 TsEvent::ClientEnterView(e) => {
@@ -127,43 +76,13 @@ impl EventRouter {
                         "Client entered view: clid={}, nickname={}",
                         e.clid, e.client_nickname
                     );
-                    self.cache_client(
-                        e.clid,
-                        e.cldbid,
-                        e.client_nickname,
-                        e.client_server_groups,
-                        e.client_channel_group_id,
-                        e.channel_id,
-                    );
                 }
                 TsEvent::ClientLeftView(e) => {
-                    self.clients.remove(&e.clid);
+                    debug!("Client left view: clid={}", e.clid);
                 }
             }
         }
         Ok(())
-    }
-
-    fn cache_client(
-        &self,
-        clid: u32,
-        cldbid: u32,
-        nickname: String,
-        server_groups: Vec<u32>,
-        channel_group_id: u32,
-        channel_id: u32,
-    ) {
-        self.clients.insert(
-            clid,
-            ClientInfo {
-                clid,
-                cldbid,
-                nickname,
-                server_groups,
-                channel_group_id,
-                channel_id,
-            },
-        );
     }
 
     async fn execute_skill(
@@ -176,7 +95,6 @@ impl EventRouter {
         if let Some(skill) = self.registry.get(&call.name) {
             let ctx = ExecutionContext {
                 adapter: self.adapter.clone(),
-                clients: self.clients.as_ref(),
                 caller_id: event.invoker_id,
                 caller_name: event.invoker_name.clone(),
                 caller_groups: groups.to_vec(),
@@ -186,7 +104,6 @@ impl EventRouter {
             };
             let unified_ctx = UnifiedExecutionContext::from_ts(&ctx).with_cross_adapters(
                 Some(self.adapter.clone()),
-                Some(self.clients.as_ref()),
                 self.nc_adapter.clone(),
             );
 
@@ -255,24 +172,39 @@ impl EventRouter {
             event.invoker_name, event.invoker_id, msg_content
         );
 
-        let (groups, channel_group_id) = if let Some(client) = self.clients.get(&event.invoker_id) {
-            (client.server_groups.clone(), client.channel_group_id)
-        } else {
-            let groups: Vec<u32> = event
-                .invoker_groups
-                .iter()
-                .filter_map(|g| g.parse().ok())
-                .collect();
-            (groups, 0)
-        };
+        let groups: Vec<u32> = event
+            .invoker_groups
+            .iter()
+            .filter_map(|g| g.parse().ok())
+            .collect();
+        let channel_group_id = 0;
 
         let source = SessionSource::TeamSpeak {
             clid: event.invoker_id,
         };
         let system_prompt = &self.prompts.system.content;
+
+        let online_clients = match self.adapter.list_clients().await {
+            Ok(clients) => {
+                let arr: Vec<_> = clients
+                    .iter()
+                    .map(|c| {
+                        let g: Vec<u32> =
+                            c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                        json!({ "clid": c.id, "nickname": c.nickname, "uid": c.uid, "groups": g, "channel_id": c.channel_id })
+                    })
+                    .collect();
+                serde_json::to_string(&arr).unwrap_or_default()
+            }
+            Err(e) => {
+                warn!("Failed to fetch online clients: {e}");
+                String::new()
+            }
+        };
+
         let user_ctx = format!(
-            "User: {} (clid: {}, groups: {:?}, channel_group: {})",
-            event.invoker_name, event.invoker_id, groups, channel_group_id
+            "User: {} (clid: {}, groups: {:?})\nOnline clients: {}",
+            event.invoker_name, event.invoker_id, groups, online_clients
         );
 
         let mut messages = self

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -26,9 +26,9 @@ use voicev1::voice_service_client::VoiceServiceClient;
 struct CallerContext {
     caller_id: u32,
     caller_name: String,
-    caller_uid: String,
     groups: Vec<u32>,
     channel_group_id: u32,
+    channel_id: u64,
     reply_target_mode: i32,
     reply_target_client_id: u32,
 }
@@ -148,25 +148,33 @@ impl VoiceRouter {
                 if let Some(c) = clients.iter().find(|c| c.nickname == chat.invoker_name) {
                     let groups: Vec<u32> =
                         c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                    debug!(
+                        "Resolved chat caller '{}' from online list: clid={}",
+                        chat.invoker_name, c.id
+                    );
                     return CallerContext {
                         caller_id: c.id as u32,
                         caller_name: chat.invoker_name.clone(),
-                        caller_uid: c.id.to_string(),
                         groups,
                         channel_group_id: 0,
+                        channel_id: c.channel_id,
                         reply_target_mode: chat.reply_target_mode,
                         reply_target_client_id: chat.reply_target_client_id,
                     };
                 }
+                debug!(
+                    "Chat caller '{}' not found in online list, using fallback",
+                    chat.invoker_name
+                );
             }
             Err(e) => warn!("Failed to list clients for chat caller resolution: {e}"),
         }
         CallerContext {
             caller_id: 0,
             caller_name: chat.invoker_name.clone(),
-            caller_uid: 0.to_string(),
             groups: vec![],
             channel_group_id: 0,
+            channel_id: 0,
             reply_target_mode: chat.reply_target_mode,
             reply_target_client_id: chat.reply_target_client_id,
         }
@@ -188,25 +196,33 @@ impl VoiceRouter {
                 if let Some(c) = clients.iter().find(|c| c.id as u32 == audio.from_client_id) {
                     let groups: Vec<u32> =
                         c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                    debug!(
+                        "Resolved audio caller '{}' from online list: clid={}",
+                        audio.from_client_name, c.id
+                    );
                     return CallerContext {
                         caller_id: c.id as u32,
                         caller_name: c.nickname.clone(),
-                        caller_uid: c.id.to_string(),
                         groups,
                         channel_group_id: 0,
+                        channel_id: c.channel_id,
                         reply_target_mode,
                         reply_target_client_id,
                     };
                 }
+                debug!(
+                    "Audio caller '{}' not found in online list, using fallback",
+                    audio.from_client_name
+                );
             }
             Err(e) => warn!("Failed to list clients for audio caller resolution: {e}"),
         }
         CallerContext {
             caller_id: audio.from_client_id,
             caller_name: audio.from_client_name.clone(),
-            caller_uid: audio.from_client_id.to_string(),
             groups: vec![],
             channel_group_id: 0,
+            channel_id: 0,
             reply_target_mode,
             reply_target_client_id,
         }
@@ -563,14 +579,13 @@ impl VoiceRouter {
 
         let online_clients = match self.ts_adapter.list_clients().await {
             Ok(clients) => {
-                let arr: Vec<_> = clients
+                let arr: Vec<serde_json::Value> = clients
                     .iter()
                     .map(|c| {
-                        let g: Vec<u32> =
-                            c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
-                        json!({ "clid": c.id, "nickname": c.nickname, "uid": c.uid, "groups": g, "channel_id": c.channel_id })
+                        json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id})
                     })
                     .collect();
+                info!("Fetched {} online clients for LLM context", clients.len());
                 serde_json::to_string(&arr).unwrap_or_default()
             }
             Err(e) => {
@@ -580,13 +595,9 @@ impl VoiceRouter {
         };
 
         let user_ctx = format!(
-            "User: {} (uid: {}, clid: {}, groups: {:?}, channel_group: {})\nOnline clients: {}",
-            ctx.caller_name,
-            ctx.caller_uid,
-            ctx.caller_id,
-            ctx.groups,
-            ctx.channel_group_id,
-            online_clients
+            r#"invoker: {{"name":"{}","clid":{},"channel_id":{}}}
+Online: {}"#,
+            ctx.caller_name, ctx.caller_id, ctx.channel_id, online_clients
         );
         let allowed_skills = self
             .gate

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use dashmap::DashMap;
 use futures_util::StreamExt;
 use serde_json::json;
 use std::sync::Arc;
@@ -21,7 +20,6 @@ use crate::adapter::TsAdapter;
 use crate::config::{AppConfig, PromptsConfig};
 use crate::llm::{LlmEngine, SessionSource, StreamCallbacks, ToolCall, ToolExecutor};
 use crate::permission::PermissionGate;
-use crate::router::ClientInfo;
 use crate::skills::{ExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use voicev1::voice_service_client::VoiceServiceClient;
 
@@ -54,7 +52,6 @@ pub struct VoiceRouter {
     llm: Arc<LlmEngine>,
     registry: Arc<SkillRegistry>,
     ts_adapter: Arc<TsAdapter>,
-    ts_clients: Arc<DashMap<u32, ClientInfo>>,
     audio_pipeline: Mutex<Option<OpusSttPipeline>>,
     speech_provider: Option<Arc<OpenAiSpeechProvider>>,
 }
@@ -72,7 +69,6 @@ impl VoiceRouter {
         llm: Arc<LlmEngine>,
         registry: Arc<SkillRegistry>,
         ts_adapter: Arc<TsAdapter>,
-        ts_clients: Arc<DashMap<u32, ClientInfo>>,
     ) -> Self {
         let speech_provider =
             OpenAiSpeechProvider::new(config.clone(), prompts.tts.style_prompt.clone())
@@ -87,7 +83,6 @@ impl VoiceRouter {
             llm,
             registry,
             ts_adapter,
-            ts_clients,
             speech_provider,
         }
     }
@@ -147,20 +142,24 @@ impl VoiceRouter {
         s
     }
 
-    fn resolve_caller_from_chat(&self, chat: &voicev1::ChatEvent) -> CallerContext {
-        for item in self.ts_clients.iter() {
-            let c = item.value();
-            if c.nickname == chat.invoker_name {
-                return CallerContext {
-                    caller_id: c.clid,
-                    caller_name: chat.invoker_name.clone(),
-                    caller_uid: c.clid.to_string(),
-                    groups: c.server_groups.clone(),
-                    channel_group_id: c.channel_group_id,
-                    reply_target_mode: chat.reply_target_mode,
-                    reply_target_client_id: chat.reply_target_client_id,
-                };
+    async fn resolve_caller_from_chat(&self, chat: &voicev1::ChatEvent) -> CallerContext {
+        match self.ts_adapter.list_clients().await {
+            Ok(clients) => {
+                if let Some(c) = clients.iter().find(|c| c.nickname == chat.invoker_name) {
+                    let groups: Vec<u32> =
+                        c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                    return CallerContext {
+                        caller_id: c.id as u32,
+                        caller_name: chat.invoker_name.clone(),
+                        caller_uid: c.id.to_string(),
+                        groups,
+                        channel_group_id: 0,
+                        reply_target_mode: chat.reply_target_mode,
+                        reply_target_client_id: chat.reply_target_client_id,
+                    };
+                }
             }
+            Err(e) => warn!("Failed to list clients for chat caller resolution: {e}"),
         }
         CallerContext {
             caller_id: 0,
@@ -173,7 +172,7 @@ impl VoiceRouter {
         }
     }
 
-    fn resolve_caller_from_audio(&self, audio: &voicev1::AudioFrameEvent) -> CallerContext {
+    async fn resolve_caller_from_audio(&self, audio: &voicev1::AudioFrameEvent) -> CallerContext {
         let reply_target_mode = match self.config.bot.default_reply_mode.as_str() {
             "channel" => 2,
             "server" => 3,
@@ -184,17 +183,23 @@ impl VoiceRouter {
         } else {
             0
         };
-        if let Some(item) = self.ts_clients.get(&audio.from_client_id) {
-            let c = item.value();
-            return CallerContext {
-                caller_id: c.clid,
-                caller_name: c.nickname.clone(),
-                caller_uid: c.clid.to_string(),
-                groups: c.server_groups.clone(),
-                channel_group_id: c.channel_group_id,
-                reply_target_mode,
-                reply_target_client_id,
-            };
+        match self.ts_adapter.list_clients().await {
+            Ok(clients) => {
+                if let Some(c) = clients.iter().find(|c| c.id as u32 == audio.from_client_id) {
+                    let groups: Vec<u32> =
+                        c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                    return CallerContext {
+                        caller_id: c.id as u32,
+                        caller_name: c.nickname.clone(),
+                        caller_uid: c.id.to_string(),
+                        groups,
+                        channel_group_id: 0,
+                        reply_target_mode,
+                        reply_target_client_id,
+                    };
+                }
+            }
+            Err(e) => warn!("Failed to list clients for audio caller resolution: {e}"),
         }
         CallerContext {
             caller_id: audio.from_client_id,
@@ -219,7 +224,6 @@ impl VoiceRouter {
         if let Some(skill) = self.registry.get(&call.name) {
             let exec_ctx = ExecutionContext {
                 adapter: self.ts_adapter.clone(),
-                clients: self.ts_clients.as_ref(),
                 caller_id: ctx.caller_id,
                 caller_name: ctx.caller_name.clone(),
                 caller_groups: ctx.groups.clone(),
@@ -229,7 +233,6 @@ impl VoiceRouter {
             };
             let unified_ctx = UnifiedExecutionContext::from_ts(&exec_ctx).with_cross_adapters(
                 Some(self.ts_adapter.clone()),
-                Some(self.ts_clients.as_ref()),
                 None,
             );
             let args = call.arguments.clone();
@@ -261,7 +264,7 @@ impl VoiceRouter {
         client: &mut VoiceServiceClient<Channel>,
         chat: voicev1::ChatEvent,
     ) -> Result<()> {
-        let ctx = self.resolve_caller_from_chat(&chat);
+        let ctx = self.resolve_caller_from_chat(&chat).await;
         if self.should_ignore_chat(&chat, ctx.caller_id) || !chat.should_trigger_llm {
             return Ok(());
         }
@@ -320,7 +323,7 @@ impl VoiceRouter {
             return Ok(());
         };
 
-        let mut ctx = self.resolve_caller_from_audio(&audio);
+        let mut ctx = self.resolve_caller_from_audio(&audio).await;
         ctx.caller_name = chunk.speaker_name;
         ctx.caller_id = chunk.speaker_client_id;
         self.handle_user_input(client, ctx, text).await
@@ -345,11 +348,11 @@ impl VoiceRouter {
         let wav_bytes = pcm16_mono_to_wav_bytes(&chunk.pcm16_mono_16k, 16_000);
         let audio_base64 = BASE64.encode(&wav_bytes);
         let audio_data = format!("data:audio/wav;base64,{}", audio_base64);
-        let mut ctx = self.resolve_caller_from_audio(&audio);
+        let mut ctx = self.resolve_caller_from_audio(&audio).await;
         ctx.caller_name = chunk.speaker_name;
         ctx.caller_id = chunk.speaker_client_id;
 
-        let (mut messages, tools, session_source) = self.build_omni_llm_request(&ctx, audio_data);
+        let (mut messages, tools, session_source) = self.build_omni_llm_request(&ctx, audio_data).await;
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
@@ -399,7 +402,7 @@ impl VoiceRouter {
     ) -> Result<()> {
         info!(event = "voice.chat.user_message", invoker = %ctx.caller_name, clid = ctx.caller_id, message = %self.truncate_for_log(&user_msg));
 
-        let (mut messages, tools, session_source) = self.build_llm_request(&ctx, user_msg.clone());
+        let (mut messages, tools, session_source) = self.build_llm_request(&ctx, user_msg.clone()).await;
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
@@ -552,15 +555,30 @@ impl VoiceRouter {
         })
     }
 
-    fn build_llm_base_context(
+    async fn build_llm_base_context(
         &self,
         ctx: &CallerContext,
     ) -> (String, String, Vec<serde_json::Value>) {
         let system_prompt = self.prompts.system.content.clone();
-        let online_clients: Vec<_> = self.ts_clients.iter().map(|item| {
-            let c = item.value();
-            json!({ "clid": c.clid, "nickname": c.nickname, "uid": c.cldbid, "groups": c.server_groups, "channel_id": c.channel_id })
-        }).collect();
+
+        let online_clients = match self.ts_adapter.list_clients().await {
+            Ok(clients) => {
+                let arr: Vec<_> = clients
+                    .iter()
+                    .map(|c| {
+                        let g: Vec<u32> =
+                            c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                        json!({ "clid": c.id, "nickname": c.nickname, "uid": c.uid, "groups": g, "channel_id": c.channel_id })
+                    })
+                    .collect();
+                serde_json::to_string(&arr).unwrap_or_default()
+            }
+            Err(e) => {
+                warn!("Failed to fetch online clients: {e}");
+                String::new()
+            }
+        };
+
         let user_ctx = format!(
             "User: {} (uid: {}, clid: {}, groups: {:?}, channel_group: {})\nOnline clients: {}",
             ctx.caller_name,
@@ -568,7 +586,7 @@ impl VoiceRouter {
             ctx.caller_id,
             ctx.groups,
             ctx.channel_group_id,
-            serde_json::to_string(&online_clients).unwrap_or_default()
+            online_clients
         );
         let allowed_skills = self
             .gate
@@ -577,7 +595,7 @@ impl VoiceRouter {
         (system_prompt, user_ctx, tools)
     }
 
-    fn build_llm_request(
+    async fn build_llm_request(
         &self,
         ctx: &CallerContext,
         user_msg: String,
@@ -586,7 +604,7 @@ impl VoiceRouter {
         Vec<serde_json::Value>,
         SessionSource,
     ) {
-        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx);
+        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx).await;
         let source = SessionSource::Headless {
             caller_id: ctx.caller_id,
         };
@@ -596,7 +614,7 @@ impl VoiceRouter {
         (messages, tools, source)
     }
 
-    fn build_omni_llm_request(
+    async fn build_omni_llm_request(
         &self,
         ctx: &CallerContext,
         audio_data: String,
@@ -605,7 +623,7 @@ impl VoiceRouter {
         Vec<serde_json::Value>,
         SessionSource,
     ) {
-        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx);
+        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx).await;
         let source = SessionSource::Headless {
             caller_id: ctx.caller_id,
         };

--- a/src/skills/information.rs
+++ b/src/skills/information.rs
@@ -1,9 +1,8 @@
 use crate::skills::{ExecutionContext, Platform, Skill, UnifiedExecutionContext};
 use anyhow::Result;
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
-use tracing::info;
+use tracing::{debug, info};
 
 pub struct GetClientInfo;
 
@@ -13,51 +12,59 @@ impl Skill for GetClientInfo {
         "get_client_info"
     }
     fn description(&self) -> &'static str {
-        "Get detailed information about an online user by their nickname, including connection time, IP address, version, and more."
+        "Get detailed information about an online user by their clid, including connection time, IP address, version, and more."
     }
     fn parameters(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
-                "nickname": { "type": "string", "description": "The nickname of the online user to query." }
+                "clid": { "type": "integer", "description": "The client ID of the online user to query." }
             },
-            "required": ["nickname"]
+            "required": ["clid"]
         })
     }
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let nickname = args["nickname"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: nickname"))?;
-
-        let clients = ctx.adapter.list_clients().await?;
-        let client = clients
-            .iter()
-            .find(|c| c.nickname == nickname)
-            .ok_or_else(|| anyhow::anyhow!("Client '{}' is not online or does not exist", nickname))?;
-        let clid = client.id as u32;
+        let clid = args["clid"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
+            as u32;
 
         let mut info = ctx.adapter.get_client_info(clid).await?;
 
-        if let Some(ts) = info.get("client_connection_connected_time") {
-            if let Ok(timestamp) = ts.parse::<i64>() {
-                if let Some(connected) = DateTime::from_timestamp(timestamp, 0) {
-                    let now = Utc::now();
-                    let secs = (now - connected).num_seconds().max(0);
+        debug!(?info, clid, "GetClientInfo raw response");
 
-                    let h = secs / 3600;
-                    let m = (secs % 3600) / 60;
-                    let s = secs % 60;
+        if let Some(ts) = info.get("connection_connected_time") {
+            if let Ok(ms) = ts.parse::<u64>() {
+                let total_secs = ms / 1000;
 
-                    let dur_str = if h > 0 {
-                        format!("{h} hours {m} minutes {s} seconds")
-                    } else if m > 0 {
-                        format!("{m} minutes {s} seconds")
+                let years = total_secs / (365 * 86400);
+                let rem = total_secs % (365 * 86400);
+                let months = rem / (30 * 86400);
+                let rem = rem % (30 * 86400);
+                let days = rem / 86400;
+                let rem = rem % 86400;
+                let hours = rem / 3600;
+                let rem = rem % 3600;
+                let minutes = rem / 60;
+                let seconds = rem % 60;
+
+                let dur_str = format!(
+                    "{}{}{}{}{}{}",
+                    if years > 0 { format!("{years} years ") } else { String::new() },
+                    if months > 0 { format!("{months} months ") } else { String::new() },
+                    if days > 0 { format!("{days} days ") } else { String::new() },
+                    if hours > 0 { format!("{hours} hours ") } else { String::new() },
+                    if minutes > 0 { format!("{minutes} minutes ") } else { String::new() },
+                    if seconds > 0 || (years == 0 && months == 0 && days == 0 && hours == 0 && minutes == 0) {
+                        format!("{seconds} seconds")
                     } else {
-                        format!("{s} seconds")
-                    };
-                    info.insert("connection_duration".to_string(), dur_str);
-                    info.remove("client_connection_connected_time");
-                }
+                        String::new()
+                    },
+                );
+                let dur_str = dur_str.trim().to_string();
+
+                info.insert("connection_duration".to_string(), dur_str);
+                info.remove("connection_connected_time");
             }
         }
 
@@ -70,16 +77,17 @@ impl Skill for GetClientInfo {
             ctx.platform
         );
 
-        let nickname = args["nickname"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: nickname"))?;
-
         match ctx.platform {
             Platform::TeamSpeak => {
                 let ts_ctx = ctx.to_ts_ctx()?;
                 return self.execute(args.clone(), &ts_ctx).await;
             }
             Platform::NapCat => {
+                let clid = args["clid"]
+                    .as_u64()
+                    .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
+                    as u32;
+
                 let ts_adapter = ctx
                     .ts_adapter
                     .clone()
@@ -88,8 +96,8 @@ impl Skill for GetClientInfo {
                 let clients = ts_adapter.list_clients().await?;
                 let client = clients
                     .iter()
-                    .find(|c| c.nickname == nickname)
-                    .ok_or_else(|| anyhow::anyhow!("Client '{}' is not online or does not exist", nickname))?;
+                    .find(|c| c.id as u32 == clid)
+                    .ok_or_else(|| anyhow::anyhow!("Client {} is not online or does not exist", clid))?;
                 let groups: Vec<u32> = client
                     .server_groups
                     .iter()

--- a/src/skills/information.rs
+++ b/src/skills/information.rs
@@ -1,91 +1,9 @@
 use crate::skills::{ExecutionContext, Platform, Skill, UnifiedExecutionContext};
 use anyhow::Result;
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use tracing::info;
-
-fn ts_client_to_json(clients: &[tsclient_rs::ClientInfo]) -> Vec<Value> {
-    clients
-        .iter()
-        .map(|c| {
-            let groups: Vec<u32> = c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
-            json!({
-                "clid": c.id,
-                "nickname": c.nickname,
-                "dbid": 0,
-                "groups": groups,
-                "channel_id": c.channel_id
-            })
-        })
-        .collect()
-}
-
-pub struct GetClientList;
-
-#[async_trait]
-impl Skill for GetClientList {
-    fn name(&self) -> &'static str {
-        "get_client_list"
-    }
-    fn description(&self) -> &'static str {
-        "Get the list of online clients."
-    }
-    fn parameters(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {},
-            "required": []
-        })
-    }
-    async fn execute(&self, _args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clients = ctx.adapter.list_clients().await?;
-        let json_clients = ts_client_to_json(&clients);
-        Ok(json!({"status": "ok", "clients": json_clients}))
-    }
-
-    async fn execute_unified(&self, args: Value, ctx: &UnifiedExecutionContext) -> Result<Value> {
-        info!(
-            "GetClientList: unified execution, platform={:?}",
-            ctx.platform
-        );
-
-        match ctx.platform {
-            Platform::TeamSpeak => {
-                let ts_ctx = ctx.to_ts_ctx()?;
-                return self.execute(args.clone(), &ts_ctx).await;
-            }
-            Platform::NapCat => {
-                let ts_adapter = ctx
-                    .ts_adapter
-                    .clone()
-                    .ok_or_else(|| anyhow::anyhow!("TeamSpeak adapter not available"))?;
-                let clients = ts_adapter.list_clients().await?;
-                let json_clients = ts_client_to_json(&clients);
-
-                let reply = if json_clients.is_empty() {
-                    "No online users on TS server".to_string()
-                } else {
-                    let names: Vec<_> = json_clients
-                        .iter()
-                        .map(|c| c["nickname"].as_str().unwrap_or("unknown"))
-                        .collect();
-                    format!(
-                        "TS server online users ({}): {}",
-                        names.len(),
-                        names.join(", ")
-                    )
-                };
-
-                Ok(json!({
-                    "status": "ok",
-                    "message": reply,
-                    "clients": json_clients,
-                    "platform": "teamspeak"
-                }))
-            }
-        }
-    }
-}
 
 pub struct GetClientInfo;
 
@@ -95,24 +13,54 @@ impl Skill for GetClientInfo {
         "get_client_info"
     }
     fn description(&self) -> &'static str {
-        "Get detailed information about a specific online client by their client ID, including connection time, IP address, version, and more."
+        "Get detailed information about an online user by their nickname, including connection time, IP address, version, and more."
     }
     fn parameters(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
-                "clid": { "type": "integer", "description": "The client ID to query." }
+                "nickname": { "type": "string", "description": "The nickname of the online user to query." }
             },
-            "required": ["clid"]
+            "required": ["nickname"]
         })
     }
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clid = args["clid"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-            as u32;
+        let nickname = args["nickname"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: nickname"))?;
 
-        let info = ctx.adapter.get_client_info(clid).await?;
+        let clients = ctx.adapter.list_clients().await?;
+        let client = clients
+            .iter()
+            .find(|c| c.nickname == nickname)
+            .ok_or_else(|| anyhow::anyhow!("Client '{}' is not online or does not exist", nickname))?;
+        let clid = client.id as u32;
+
+        let mut info = ctx.adapter.get_client_info(clid).await?;
+
+        if let Some(ts) = info.get("client_connection_connected_time") {
+            if let Ok(timestamp) = ts.parse::<i64>() {
+                if let Some(connected) = DateTime::from_timestamp(timestamp, 0) {
+                    let now = Utc::now();
+                    let secs = (now - connected).num_seconds().max(0);
+
+                    let h = secs / 3600;
+                    let m = (secs % 3600) / 60;
+                    let s = secs % 60;
+
+                    let dur_str = if h > 0 {
+                        format!("{h} hours {m} minutes {s} seconds")
+                    } else if m > 0 {
+                        format!("{m} minutes {s} seconds")
+                    } else {
+                        format!("{s} seconds")
+                    };
+                    info.insert("connection_duration".to_string(), dur_str);
+                    info.remove("client_connection_connected_time");
+                }
+            }
+        }
+
         Ok(json!({"status": "ok", "client_info": info}))
     }
 
@@ -121,6 +69,10 @@ impl Skill for GetClientInfo {
             "GetClientInfo: unified execution, platform={:?}",
             ctx.platform
         );
+
+        let nickname = args["nickname"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: nickname"))?;
 
         match ctx.platform {
             Platform::TeamSpeak => {
@@ -132,16 +84,12 @@ impl Skill for GetClientInfo {
                     .ts_adapter
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("TeamSpeak adapter not available"))?;
-                let clid = args["clid"]
-                    .as_u64()
-                    .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-                    as u32;
 
                 let clients = ts_adapter.list_clients().await?;
                 let client = clients
                     .iter()
-                    .find(|c| c.id as u32 == clid)
-                    .ok_or_else(|| anyhow::anyhow!("Client {} is not online or does not exist", clid))?;
+                    .find(|c| c.nickname == nickname)
+                    .ok_or_else(|| anyhow::anyhow!("Client '{}' is not online or does not exist", nickname))?;
                 let groups: Vec<u32> = client
                     .server_groups
                     .iter()

--- a/src/skills/information.rs
+++ b/src/skills/information.rs
@@ -4,6 +4,22 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use tracing::info;
 
+fn ts_client_to_json(clients: &[tsclient_rs::ClientInfo]) -> Vec<Value> {
+    clients
+        .iter()
+        .map(|c| {
+            let groups: Vec<u32> = c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+            json!({
+                "clid": c.id,
+                "nickname": c.nickname,
+                "dbid": 0,
+                "groups": groups,
+                "channel_id": c.channel_id
+            })
+        })
+        .collect()
+}
+
 pub struct GetClientList;
 
 #[async_trait]
@@ -22,20 +38,8 @@ impl Skill for GetClientList {
         })
     }
     async fn execute(&self, _args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clients: Vec<_> = ctx.clients.iter().map(|r| r.value().clone()).collect();
-        let json_clients: Vec<_> = clients
-            .iter()
-            .map(|c| {
-                json!({
-                    "clid": c.clid,
-                    "nickname": c.nickname,
-                    "dbid": c.cldbid,
-                    "groups": c.server_groups,
-                    "channel_id": c.channel_id
-                })
-            })
-            .collect();
-
+        let clients = ctx.adapter.list_clients().await?;
+        let json_clients = ts_client_to_json(&clients);
         Ok(json!({"status": "ok", "clients": json_clients}))
     }
 
@@ -51,44 +55,33 @@ impl Skill for GetClientList {
                 return self.execute(args.clone(), &ts_ctx).await;
             }
             Platform::NapCat => {
-                // NC 请求查询 TS 在线列表
-                if let Some(ref ts_clients) = ctx.ts_clients {
-                    let clients: Vec<_> = ts_clients.iter().map(|r| r.value().clone()).collect();
-                    let json_clients: Vec<_> = clients
+                let ts_adapter = ctx
+                    .ts_adapter
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("TeamSpeak adapter not available"))?;
+                let clients = ts_adapter.list_clients().await?;
+                let json_clients = ts_client_to_json(&clients);
+
+                let reply = if json_clients.is_empty() {
+                    "No online users on TS server".to_string()
+                } else {
+                    let names: Vec<_> = json_clients
                         .iter()
-                        .map(|c| {
-                            json!({
-                                "clid": c.clid,
-                                "nickname": c.nickname,
-                                "dbid": c.cldbid,
-                                "groups": c.server_groups,
-                                "channel_id": c.channel_id
-                            })
-                        })
+                        .map(|c| c["nickname"].as_str().unwrap_or("unknown"))
                         .collect();
+                    format!(
+                        "TS server online users ({}): {}",
+                        names.len(),
+                        names.join(", ")
+                    )
+                };
 
-                    let reply = if json_clients.is_empty() {
-                        "No online users on TS server".to_string()
-                    } else {
-                        let names: Vec<_> = json_clients
-                            .iter()
-                            .map(|c| c["nickname"].as_str().unwrap_or("unknown"))
-                            .collect();
-                        format!(
-                            "TS server online users ({}): {}",
-                            names.len(),
-                            names.join(", ")
-                        )
-                    };
-
-                    return Ok(json!({
-                        "status": "ok",
-                        "message": reply,
-                        "clients": json_clients,
-                        "platform": "teamspeak"
-                    }));
-                }
-                Err(anyhow::anyhow!("TeamSpeak clients list not available"))
+                Ok(json!({
+                    "status": "ok",
+                    "message": reply,
+                    "clients": json_clients,
+                    "platform": "teamspeak"
+                }))
             }
         }
     }
@@ -119,12 +112,6 @@ impl Skill for GetClientInfo {
             .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
             as u32;
 
-        // 确认目标客户端在线
-        if !ctx.clients.contains_key(&clid) {
-            let msg = format!("Client {} is not online or does not exist", clid);
-            return Ok(json!({"status": "error", "message": msg}));
-        }
-
         let info = ctx.adapter.get_client_info(clid).await?;
         Ok(json!({"status": "ok", "client_info": info}))
     }
@@ -141,35 +128,35 @@ impl Skill for GetClientInfo {
                 return self.execute(args.clone(), &ts_ctx).await;
             }
             Platform::NapCat => {
-                // NC 请求查询 TS 指定用户信息
+                let ts_adapter = ctx
+                    .ts_adapter
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("TeamSpeak adapter not available"))?;
                 let clid = args["clid"]
                     .as_u64()
                     .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
                     as u32;
 
-                if let Some(ref ts_clients) = ctx.ts_clients {
-                    let Some(client) = ts_clients.get(&clid) else {
-                        return Ok(json!({
-                            "status": "error",
-                            "message": format!("Client {} is not online or does not exist", clid)
-                        }));
-                    };
-                    let reply = format!(
-                        "TS user info - nickname:{}, ID:{}, DBID:{}, server groups:{:?}, channel ID:{}",
-                        client.nickname,
-                        client.clid,
-                        client.cldbid,
-                        client.server_groups,
-                        client.channel_id
-                    );
+                let clients = ts_adapter.list_clients().await?;
+                let client = clients
+                    .iter()
+                    .find(|c| c.id as u32 == clid)
+                    .ok_or_else(|| anyhow::anyhow!("Client {} is not online or does not exist", clid))?;
+                let groups: Vec<u32> = client
+                    .server_groups
+                    .iter()
+                    .filter_map(|g| g.parse().ok())
+                    .collect();
+                let reply = format!(
+                    "TS user info - nickname:{}, ID:{}, server groups:{:?}, channel ID:{}",
+                    client.nickname, client.id, groups, client.channel_id
+                );
 
-                    return Ok(json!({
-                        "status": "ok",
-                        "message": reply,
-                        "platform": "teamspeak"
-                    }));
-                }
-                Err(anyhow::anyhow!("TeamSpeak clients list not available"))
+                Ok(json!({
+                    "status": "ok",
+                    "message": reply,
+                    "platform": "teamspeak"
+                }))
             }
         }
     }

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -7,7 +7,6 @@ use crate::adapter::napcat::NapCatAdapter;
 use crate::adapter::TsAdapter;
 use crate::config::AppConfig;
 use crate::permission::PermissionGate;
-use crate::router::ClientInfo;
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -28,9 +27,8 @@ pub enum Platform {
 // TeamSpeak 执行上下文（原有）
 // ─────────────────────────────────────────────
 
-pub struct ExecutionContext<'a> {
+pub struct ExecutionContext {
     pub adapter: Arc<TsAdapter>,
-    pub clients: &'a DashMap<u32, ClientInfo>,
     pub caller_id: u32,
     pub caller_name: String,
     pub caller_groups: Vec<u32>,
@@ -56,10 +54,9 @@ pub struct NcExecutionContext {
 // 统一执行上下文（跨平台）
 // ─────────────────────────────────────────────
 
-pub struct UnifiedExecutionContext<'a> {
+pub struct UnifiedExecutionContext {
     pub platform: Platform,
     pub ts_adapter: Option<Arc<TsAdapter>>,
-    pub ts_clients: Option<&'a DashMap<u32, ClientInfo>>,
     pub nc_adapter: Option<Arc<NapCatAdapter>>,
     pub caller_id: u32,
     pub caller_id_nc: i64,
@@ -71,12 +68,11 @@ pub struct UnifiedExecutionContext<'a> {
     pub config: Arc<AppConfig>,
 }
 
-impl<'a> UnifiedExecutionContext<'a> {
-    pub fn from_ts(ctx: &ExecutionContext<'a>) -> Self {
+impl UnifiedExecutionContext {
+    pub fn from_ts(ctx: &ExecutionContext) -> Self {
         Self {
             platform: Platform::TeamSpeak,
             ts_adapter: Some(ctx.adapter.clone()),
-            ts_clients: Some(ctx.clients),
             nc_adapter: None,
             caller_id: ctx.caller_id,
             caller_id_nc: 0,
@@ -93,7 +89,6 @@ impl<'a> UnifiedExecutionContext<'a> {
         Self {
             platform: Platform::NapCat,
             ts_adapter: None,
-            ts_clients: None,
             nc_adapter: Some(ctx.adapter.clone()),
             caller_id: 0,
             caller_id_nc: ctx.caller_id,
@@ -109,25 +104,20 @@ impl<'a> UnifiedExecutionContext<'a> {
     pub fn with_cross_adapters(
         mut self,
         ts_adapter: Option<Arc<TsAdapter>>,
-        ts_clients: Option<&'a DashMap<u32, ClientInfo>>,
         nc_adapter: Option<Arc<NapCatAdapter>>,
     ) -> Self {
         self.ts_adapter = ts_adapter;
-        self.ts_clients = ts_clients;
         self.nc_adapter = nc_adapter;
         self
     }
 
     /// 从统一上下文还原 TeamSpeak 执行上下文
-    pub fn to_ts_ctx(&self) -> Result<ExecutionContext<'a>> {
+    pub fn to_ts_ctx(&self) -> Result<ExecutionContext> {
         Ok(ExecutionContext {
             adapter: self
                 .ts_adapter
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("TeamSpeak adapter not available"))?,
-            clients: self
-                .ts_clients
-                .ok_or_else(|| anyhow::anyhow!("TeamSpeak clients list not available"))?,
             caller_id: self.caller_id,
             caller_name: self.caller_name.clone(),
             caller_groups: self.caller_groups.clone(),

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -172,7 +172,7 @@ pub struct SkillRegistry {
 impl SkillRegistry {
     pub fn with_defaults(music_backend: &str) -> Self {
         use communication::{PokeClient, SendMessage};
-        use information::{GetClientInfo, GetClientList};
+        use information::GetClientInfo;
         use moderation::{BanClient, KickClient, MoveClient};
         use music::MusicControl;
         use tracing::info;
@@ -183,7 +183,6 @@ impl SkillRegistry {
         registry.register(Box::new(KickClient));
         registry.register(Box::new(BanClient));
         registry.register(Box::new(MoveClient));
-        registry.register(Box::new(GetClientList));
         registry.register(Box::new(GetClientInfo));
         registry.register(Box::new(MusicControl::new(music_backend)));
         info!("Skills registered: {:?}", registry.list_skills());

--- a/src/skills/moderation.rs
+++ b/src/skills/moderation.rs
@@ -13,14 +13,12 @@ async fn validate_target(ctx: &ExecutionContext, clid: u32) -> Result<Vec<u32>> 
     }
 
     // 获取目标的组信息（实时查询）
-    let target_groups = match ctx.adapter.list_clients().await {
-        Ok(clients) => clients
-            .iter()
-            .find(|c| c.id as u32 == clid)
-            .map(|c| c.server_groups.iter().filter_map(|g| g.parse().ok()).collect())
-            .unwrap_or_default(),
-        Err(_) => vec![],
-    };
+    let clients = ctx.adapter.list_clients().await?;
+    let target_groups: Vec<u32> = clients
+        .iter()
+        .find(|c| c.id as u32 == clid)
+        .map(|c| c.server_groups.iter().filter_map(|g| g.parse().ok()).collect())
+        .unwrap_or_default();
 
     // 检查是否可以对目标执行操作
     if !ctx.gate.can_target(

--- a/src/skills/moderation.rs
+++ b/src/skills/moderation.rs
@@ -6,18 +6,21 @@ use tracing::info;
 
 /// 检查是否可以对目标执行操作
 /// 返回目标的组信息（如果存在）和权限检查结果
-fn validate_target(ctx: &ExecutionContext, clid: u32) -> Result<Vec<u32>> {
+async fn validate_target(ctx: &ExecutionContext, clid: u32) -> Result<Vec<u32>> {
     // 自操作防护
     if clid == ctx.caller_id {
         return Err(anyhow::anyhow!("Cannot perform this action on yourself"));
     }
 
-    // 获取目标的组信息
-    let target_groups = ctx
-        .clients
-        .get(&clid)
-        .map(|c| c.server_groups.clone())
-        .unwrap_or_default();
+    // 获取目标的组信息（实时查询）
+    let target_groups = match ctx.adapter.list_clients().await {
+        Ok(clients) => clients
+            .iter()
+            .find(|c| c.id as u32 == clid)
+            .map(|c| c.server_groups.iter().filter_map(|g| g.parse().ok()).collect())
+            .unwrap_or_default(),
+        Err(_) => vec![],
+    };
 
     // 检查是否可以对目标执行操作
     if !ctx.gate.can_target(
@@ -33,7 +36,7 @@ fn validate_target(ctx: &ExecutionContext, clid: u32) -> Result<Vec<u32>> {
     Ok(target_groups)
 }
 
-async fn validate_channel_exists(ctx: &ExecutionContext<'_>, channel_id: u32) -> Result<()> {
+async fn validate_channel_exists(ctx: &ExecutionContext, channel_id: u32) -> Result<()> {
     if channel_id == 0 {
         return Err(anyhow::anyhow!("Target channel ID must be greater than 0"));
     }
@@ -76,7 +79,7 @@ impl Skill for KickClient {
         let reason = args["reason"].as_str().unwrap_or("Kicked by bot");
 
         // 权限和自操作检查
-        validate_target(ctx, clid)?;
+        validate_target(ctx, clid).await?;
 
         ctx.adapter.kick(clid, reason).await?;
         Ok(json!({"status": "ok", "message": "Client kicked"}))
@@ -120,7 +123,7 @@ impl Skill for BanClient {
         let reason = args["reason"].as_str().unwrap_or("Banned by bot");
 
         // 权限和自操作检查
-        validate_target(ctx, clid)?;
+        validate_target(ctx, clid).await?;
 
         ctx.adapter.ban(clid, time, reason).await?;
         Ok(json!({"status": "ok", "message": "Client banned"}))
@@ -166,14 +169,7 @@ impl Skill for MoveClient {
             .ok_or_else(|| anyhow::anyhow!("Missing required parameter: channel_id"))?
             as u32;
 
-        validate_target(ctx, clid)?;
-
-        if !ctx.clients.contains_key(&clid) {
-            return Err(anyhow::anyhow!(
-                "Client {} is not online or does not exist",
-                clid
-            ));
-        }
+        validate_target(ctx, clid).await?;
 
         validate_channel_exists(ctx, channel_id).await?;
 

--- a/src/skills/music/mod.rs
+++ b/src/skills/music/mod.rs
@@ -13,7 +13,7 @@ async fn dispatch_backend(
     action: &str,
     args: &Value,
     cfg: &MusicBackendConfig,
-    ts_ctx: Option<&ExecutionContext<'_>>,
+    ts_ctx: Option<&ExecutionContext>,
 ) -> Result<Value> {
     let ctx = ts_ctx
         .ok_or_else(|| anyhow::anyhow!("{} backend requires TeamSpeak context", cfg.backend))?;

--- a/src/skills/music/ts3audiobot.rs
+++ b/src/skills/music/ts3audiobot.rs
@@ -12,7 +12,7 @@ static TS3AUDIOBOT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 pub(crate) async fn execute(
     action: &str,
     args: &Value,
-    ctx: &ExecutionContext<'_>,
+    ctx: &ExecutionContext,
 ) -> Result<Value> {
     // Validate required parameters before building commands
     let needs_value = matches!(
@@ -74,7 +74,7 @@ pub(crate) async fn execute(
     };
 
     let target_name = &ctx.config.music_backend.musicbot_name;
-    let clients: Vec<_> = ctx.clients.iter().map(|r| r.value().clone()).collect();
+    let clients = ctx.adapter.list_clients().await?;
     let audiobot = clients
         .iter()
         .find(|c| {
@@ -89,7 +89,7 @@ pub(crate) async fn execute(
     let mut ts_rx = ctx.adapter.subscribe();
 
     ctx.adapter
-        .send_text_message(1, audiobot.clid, &bot_cmd)
+        .send_text_message(1, audiobot.id as u32, &bot_cmd)
         .await?;
 
     let reply = tokio::time::timeout(Duration::from_secs(10), async {

--- a/src/skills/music/tsmusicbot.rs
+++ b/src/skills/music/tsmusicbot.rs
@@ -12,7 +12,7 @@ static TSMUSICBOT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 pub(crate) async fn execute(
     action: &str,
     args: &Value,
-    ctx: &ExecutionContext<'_>,
+    ctx: &ExecutionContext,
 ) -> Result<Value> {
     let needs_value = matches!(
         action,
@@ -57,7 +57,7 @@ pub(crate) async fn execute(
     };
 
     let target_name = &ctx.config.music_backend.musicbot_name;
-    let clients: Vec<_> = ctx.clients.iter().map(|r| r.value().clone()).collect();
+    let clients = ctx.adapter.list_clients().await?;
     let audiobot = clients
         .iter()
         .find(|c| {
@@ -73,7 +73,7 @@ pub(crate) async fn execute(
         ts_rx = ctx.adapter.subscribe();
 
         ctx.adapter
-            .send_text_message(1, audiobot.clid, &bot_cmd)
+            .send_text_message(1, audiobot.id as u32, &bot_cmd)
             .await?;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

将缓存的 TeamSpeak 客户端列表替换为实时适配器查询，并更新技能和路由器，以使用实时在线客户端数据而不是共享客户端缓存。

新功能：
- 暴露一个 `get_client_info` 技能，通过昵称查询在线用户，并返回包含人类可读连接时长在内的丰富信息。

错误修复：
- 通过直接查询适配器并按昵称或客户端 ID 匹配用户，修复 NapCat 和语音路由路径中在线列表的使用问题。

优化与增强：
- 通过移除客户端进入/离开事件以及基于 DashMap 的客户端缓存，简化 EventRouter 和各适配器。
- 更新文本和语音路由器，从 TeamSpeak 适配器获取最新的在线客户端列表，以解析来电者上下文并构建 LLM 提示。
- 调整审核和音乐技能，通过实时客户端查询来查找目标用户和音乐机器人，并在没有客户端缓存的新执行上下文中正常工作。
- 改进启动日志，在可能的情况下包含机器人昵称、ID 和频道信息，并使用当前 TeamSpeak 在线用户丰富 NapCat 的用户上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace cached TeamSpeak client list with real-time adapter queries and update skills and routers to work from live online client data instead of shared client cache.

New Features:
- Expose a get_client_info skill that queries online users by nickname and returns enriched information including human-readable connection duration.

Bug Fixes:
- Fix online list usage in NapCat and voice routing paths by querying the adapter directly and matching users by nickname or client ID.

Enhancements:
- Simplify EventRouter and adapters by removing client enter/leave events and DashMap-based client cache.
- Update text and voice routers to resolve caller context and build LLM prompts using fresh online client lists from the TeamSpeak adapter.
- Adjust moderation and music skills to look up targets and music bots via live client queries and to work with the new execution context without client cache.
- Improve startup logging to include bot nickname, ID, and channel when available, and enrich NapCat user context with current TeamSpeak online users.

</details>