### PR TITLE
feat: websearch

### DIFF
--- a/src/llm/tool_loop.rs
+++ b/src/llm/tool_loop.rs
@@ -131,7 +131,6 @@ pub async fn run_tool_loop(
             info!(
                 event = "tool_loop.execute",
                 tool_name = %call.name,
-                tool_call_id = %call.id,
                 "executing tool call"
             );
 
@@ -140,7 +139,6 @@ pub async fn run_tool_loop(
             info!(
                 event = "tool_loop.result",
                 tool_name = %call.name,
-                tool_call_id = %call.id,
                 "tool execution completed"
             );
 

--- a/src/router/ts_router.rs
+++ b/src/router/ts_router.rs
@@ -5,12 +5,12 @@ use crate::llm::context::SessionSource;
 use crate::llm::{LlmEngine, ToolCall, ToolExecutor};
 use crate::permission::PermissionGate;
 use crate::router::{ReplyPolicy, UnifiedInboundEvent};
-use crate::skills::{ExecutionContext, SkillRegistry, UnifiedExecutionContext};
+use crate::skills::{ExecutionContext, SkillRegistry};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 struct SqExecutor<'a> {
     router: &'a EventRouter,
@@ -79,44 +79,18 @@ impl EventRouter {
         groups: &[u32],
         channel_group_id: u32,
     ) -> String {
-        if let Some(skill) = self.registry.get(&call.name) {
-            let ctx = ExecutionContext {
-                adapter: self.adapter.clone(),
-                caller_id: event.invoker_id,
-                caller_name: event.invoker_name.clone(),
-                caller_groups: groups.to_vec(),
-                caller_channel_group_id: channel_group_id,
-                gate: self.gate.clone(),
-                config: self.config.clone(),
-            };
-            let unified_ctx = UnifiedExecutionContext::from_ts(&ctx).with_cross_adapters(
-                Some(self.adapter.clone()),
-                self.nc_adapter.clone(),
-            );
-
-            let args = call.arguments.clone();
-            let result = match skill.execute_unified(args.clone(), &unified_ctx).await {
-                Ok(val) => {
-                    info!(skill = %call.name, caller = %event.invoker_name, "Unified skill executed successfully");
-                    Ok(val)
-                }
-                Err(unified_err) => {
-                    debug!(skill = %call.name, error = %unified_err, "Falling back to TS execution");
-                    skill.execute(args, &ctx).await
-                }
-            };
-
-            match result {
-                Ok(val) => val.to_string(),
-                Err(e) => {
-                    error!(skill = %call.name, error = %e, "Skill execution failed");
-                    format!("Skill execution failed: {}", e)
-                }
-            }
-        } else {
-            warn!(caller = %event.invoker_name, skill = %call.name, "Skill not found");
-            "Skill not found".to_string()
-        }
+        let ctx = ExecutionContext {
+            adapter: self.adapter.clone(),
+            caller_id: event.invoker_id,
+            caller_name: event.invoker_name.clone(),
+            caller_groups: groups.to_vec(),
+            caller_channel_group_id: channel_group_id,
+            gate: self.gate.clone(),
+            config: self.config.clone(),
+        };
+        self.registry
+            .execute_skill(call, ctx, self.nc_adapter.clone())
+            .await
     }
 
     async fn handle_message(&self, event: TextMessageEvent) {

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -20,7 +20,7 @@ use crate::adapter::TsAdapter;
 use crate::config::{AppConfig, PromptsConfig};
 use crate::llm::{LlmEngine, SessionSource, StreamCallbacks, ToolCall, ToolExecutor};
 use crate::permission::PermissionGate;
-use crate::skills::{ExecutionContext, SkillRegistry, UnifiedExecutionContext};
+use crate::skills::{ExecutionContext, SkillRegistry};
 use voicev1::voice_service_client::VoiceServiceClient;
 
 struct CallerContext {
@@ -146,8 +146,11 @@ impl VoiceRouter {
         match self.ts_adapter.list_clients().await {
             Ok(clients) => {
                 if let Some(c) = clients.iter().find(|c| c.nickname == chat.invoker_name) {
-                    let groups: Vec<u32> =
-                        c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                    let groups: Vec<u32> = c
+                        .server_groups
+                        .iter()
+                        .filter_map(|g| g.parse().ok())
+                        .collect();
                     debug!(
                         "Resolved chat caller '{}' from online list: clid={}",
                         chat.invoker_name, c.id
@@ -194,8 +197,11 @@ impl VoiceRouter {
         match self.ts_adapter.list_clients().await {
             Ok(clients) => {
                 if let Some(c) = clients.iter().find(|c| c.id as u32 == audio.from_client_id) {
-                    let groups: Vec<u32> =
-                        c.server_groups.iter().filter_map(|g| g.parse().ok()).collect();
+                    let groups: Vec<u32> = c
+                        .server_groups
+                        .iter()
+                        .filter_map(|g| g.parse().ok())
+                        .collect();
                     debug!(
                         "Resolved audio caller '{}' from online list: clid={}",
                         audio.from_client_name, c.id
@@ -237,42 +243,16 @@ impl VoiceRouter {
     }
 
     async fn execute_skill(&self, call: &ToolCall, ctx: &CallerContext) -> String {
-        if let Some(skill) = self.registry.get(&call.name) {
-            let exec_ctx = ExecutionContext {
-                adapter: self.ts_adapter.clone(),
-                caller_id: ctx.caller_id,
-                caller_name: ctx.caller_name.clone(),
-                caller_groups: ctx.groups.clone(),
-                caller_channel_group_id: ctx.channel_group_id,
-                gate: self.gate.clone(),
-                config: self.config.clone(),
-            };
-            let unified_ctx = UnifiedExecutionContext::from_ts(&exec_ctx).with_cross_adapters(
-                Some(self.ts_adapter.clone()),
-                None,
-            );
-            let args = call.arguments.clone();
-            let result = match skill.execute_unified(args.clone(), &unified_ctx).await {
-                Ok(val) => {
-                    info!(skill = %call.name, caller = %ctx.caller_name, "Voice unified skill executed successfully");
-                    Ok(val)
-                }
-                Err(unified_err) => {
-                    debug!(skill = %call.name, error = %unified_err, "Falling back to TS execution");
-                    skill.execute(args, &exec_ctx).await
-                }
-            };
-            match result {
-                Ok(val) => val.to_string(),
-                Err(e) => {
-                    error!(skill = %call.name, error = %e, "Skill execution failed");
-                    format!("Skill execution failed: {}", e)
-                }
-            }
-        } else {
-            warn!(caller = %ctx.caller_name, skill = %call.name, "Skill not found");
-            "Skill not found".to_string()
-        }
+        let exec_ctx = ExecutionContext {
+            adapter: self.ts_adapter.clone(),
+            caller_id: ctx.caller_id,
+            caller_name: ctx.caller_name.clone(),
+            caller_groups: ctx.groups.clone(),
+            caller_channel_group_id: ctx.channel_group_id,
+            gate: self.gate.clone(),
+            config: self.config.clone(),
+        };
+        self.registry.execute_skill(call, exec_ctx, None).await
     }
 
     async fn handle_chat_event(
@@ -368,7 +348,8 @@ impl VoiceRouter {
         ctx.caller_name = chunk.speaker_name;
         ctx.caller_id = chunk.speaker_client_id;
 
-        let (mut messages, tools, session_source) = self.build_omni_llm_request(&ctx, audio_data).await;
+        let (mut messages, tools, session_source) =
+            self.build_omni_llm_request(&ctx, audio_data).await;
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
@@ -418,7 +399,8 @@ impl VoiceRouter {
     ) -> Result<()> {
         info!(event = "voice.chat.user_message", invoker = %ctx.caller_name, clid = ctx.caller_id, message = %self.truncate_for_log(&user_msg));
 
-        let (mut messages, tools, session_source) = self.build_llm_request(&ctx, user_msg.clone()).await;
+        let (mut messages, tools, session_source) =
+            self.build_llm_request(&ctx, user_msg.clone()).await;
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
@@ -581,9 +563,7 @@ impl VoiceRouter {
             Ok(clients) => {
                 let arr: Vec<serde_json::Value> = clients
                     .iter()
-                    .map(|c| {
-                        json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id})
-                    })
+                    .map(|c| json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id}))
                     .collect();
                 info!("Fetched {} online clients for LLM context", clients.len());
                 serde_json::to_string(&arr).unwrap_or_default()

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -2,13 +2,16 @@ pub mod communication;
 pub mod information;
 pub mod moderation;
 pub mod music;
+pub mod web_search;
 
 use crate::adapter::napcat::NapCatAdapter;
 use crate::adapter::TsAdapter;
 use crate::config::AppConfig;
+use crate::llm::ToolCall;
 use crate::permission::PermissionGate;
 use anyhow::Result;
 use async_trait::async_trait;
+use tracing::{debug, error, warn};
 use dashmap::DashMap;
 use serde_json::Value;
 use std::sync::Arc;
@@ -175,6 +178,7 @@ impl SkillRegistry {
         use information::GetClientInfo;
         use moderation::{BanClient, KickClient, MoveClient};
         use music::MusicControl;
+        use web_search::WebSearch;
         use tracing::info;
 
         let registry = Self::default();
@@ -184,6 +188,7 @@ impl SkillRegistry {
         registry.register(Box::new(BanClient));
         registry.register(Box::new(MoveClient));
         registry.register(Box::new(GetClientInfo));
+        registry.register(Box::new(WebSearch));
         registry.register(Box::new(MusicControl::new(music_backend)));
         info!("Skills registered: {:?}", registry.list_skills());
         registry
@@ -199,6 +204,39 @@ impl SkillRegistry {
 
     pub fn list_skills(&self) -> Vec<String> {
         self.skills.iter().map(|s| s.key().clone()).collect()
+    }
+
+    pub async fn execute_skill(
+        &self,
+        call: &ToolCall,
+        exec_ctx: ExecutionContext,
+        nc_adapter: Option<Arc<NapCatAdapter>>,
+    ) -> String {
+        if let Some(skill) = self.get(&call.name) {
+            let ts_adapter = Some(exec_ctx.adapter.clone());
+            let unified_ctx = UnifiedExecutionContext::from_ts(&exec_ctx)
+                .with_cross_adapters(ts_adapter, nc_adapter);
+
+            let args = call.arguments.clone();
+            let result = match skill.execute_unified(args.clone(), &unified_ctx).await {
+                Ok(val) => Ok(val),
+                Err(unified_err) => {
+                    debug!(skill = %call.name, error = %unified_err, "Falling back to TS execution");
+                    skill.execute(args, &exec_ctx).await
+                }
+            };
+
+            match result {
+                Ok(val) => val.to_string(),
+                Err(e) => {
+                    error!(skill = %call.name, error = %e, "Skill execution failed");
+                    format!("Skill execution failed: {}", e)
+                }
+            }
+        } else {
+            warn!(skill = %call.name, "Skill not found");
+            "Skill not found".to_string()
+        }
     }
 
     pub fn to_tool_schemas(&self, allowed_skills: &[String]) -> Vec<Value> {

--- a/src/skills/music/tsbot_http.rs
+++ b/src/skills/music/tsbot_http.rs
@@ -9,7 +9,7 @@ fn shared_client() -> &'static reqwest::Client {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(15))
             .build()
-            .unwrap_or_default()
+            .expect("failed to build reqwest::Client for music HTTP backend")
     })
 }
 

--- a/src/skills/web_search.rs
+++ b/src/skills/web_search.rs
@@ -16,7 +16,7 @@ fn shared_client() -> &'static reqwest::Client {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(TIMEOUT_SECS))
             .build()
-            .unwrap_or_default()
+            .expect("failed to build reqwest::Client with configured timeout")
     })
 }
 
@@ -119,7 +119,7 @@ async fn execute_search(args: Value) -> Result<Value> {
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing required parameter: query"))?;
 
-    let num_results = args["num_results"]
+    let num_results = args["numResults"]
         .as_u64()
         .unwrap_or(8)
         .min(MAX_RESULTS as u64) as u8;

--- a/src/skills/web_search.rs
+++ b/src/skills/web_search.rs
@@ -1,0 +1,137 @@
+use crate::skills::{ExecutionContext, Skill, UnifiedExecutionContext};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tracing::debug;
+
+const EXA_MCP_URL: &str = "https://mcp.exa.ai/mcp";
+const MAX_RESULTS: u8 = 20;
+const TIMEOUT_SECS: u64 = 25;
+
+fn shared_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(TIMEOUT_SECS))
+            .build()
+            .unwrap_or_default()
+    })
+}
+
+async fn search_exa(query: &str, num_results: u8, search_type: &str) -> Result<String> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "web_search_exa",
+            "arguments": {
+                "query": query,
+                "type": search_type,
+                "numResults": num_results,
+                "livecrawl": "fallback"
+            }
+        }
+    });
+
+    let resp = shared_client()
+        .post(EXA_MCP_URL)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let text = resp.text().await?;
+
+    if !status.is_success() {
+        anyhow::bail!("Exa MCP returned status {}: {}", status, text);
+    }
+
+    let trimmed = text.trim();
+    if let Some(result) = parse_payload(trimmed) {
+        return Ok(result);
+    }
+
+    for line in text.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            if let Some(result) = parse_payload(data.trim()) {
+                return Ok(result);
+            }
+        }
+    }
+
+    anyhow::bail!("No search results found in response")
+}
+
+fn parse_payload(payload: &str) -> Option<String> {
+    if !payload.starts_with('{') {
+        return None;
+    }
+    let parsed: Value = serde_json::from_str(payload).ok()?;
+    let content = parsed
+        .get("result")?
+        .get("content")?
+        .as_array()?
+        .iter()
+        .filter_map(|item| item.get("text")?.as_str())
+        .next()?;
+    Some(content.to_string())
+}
+
+pub struct WebSearch;
+
+#[async_trait]
+impl Skill for WebSearch {
+    fn name(&self) -> &'static str {
+        "web_search"
+    }
+    fn description(&self) -> &'static str {
+        "Search the web for current information beyond knowledge cutoff. Use this to get up-to-date data, news, or any information that may have changed since the model's training date."
+    }
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "The search query to look up on the web." },
+                "numResults": { "type": "integer", "description": "Number of search results to return (1-20, default: 8)", "minimum": 1, "maximum": MAX_RESULTS },
+                "type": { "type": "string", "enum": ["auto", "fast", "deep"], "description": "Search type - auto: balanced, fast: quick results, deep: comprehensive (default: auto)" }
+            },
+            "required": ["query"]
+        })
+    }
+
+    async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
+        let _ = ctx;
+        execute_search(args).await
+    }
+
+    async fn execute_unified(&self, args: Value, _ctx: &UnifiedExecutionContext) -> Result<Value> {
+        execute_search(args).await
+    }
+}
+
+async fn execute_search(args: Value) -> Result<Value> {
+    let query = args["query"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Missing required parameter: query"))?;
+
+    let num_results = args["num_results"]
+        .as_u64()
+        .unwrap_or(8)
+        .min(MAX_RESULTS as u64) as u8;
+
+    let search_type = args["type"].as_str().unwrap_or("auto");
+
+    debug!(query, num_results, search_type, "WebSearch executing");
+
+    let result = search_exa(query, num_results, search_type).await?;
+
+    Ok(json!({
+        "status": "ok",
+        "result": result
+    }))
+}


### PR DESCRIPTION
close #51

## Summary by Sourcery

添加一个由外部 MCP 服务支持的网页搜索技能，并通过 SkillRegistry 集中统一管理 TS 和语音路由的技能执行。

新功能：
- 引入 WebSearch 技能，通过 Exa MCP 端点执行最新的网页查询。

改进：
- 重构 TS 和语音路由，使其将技能执行委托给 SkillRegistry，从而共享统一的执行逻辑。
- 精简工具循环的日志输出，在执行和结果事件中移除工具调用标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a web search skill backed by an external MCP service and centralize unified skill execution through the SkillRegistry for both TS and voice routers.

New Features:
- Introduce a WebSearch skill that performs up-to-date web queries via the Exa MCP endpoint.

Enhancements:
- Refactor TS and voice routers to delegate skill execution to SkillRegistry, sharing unified execution logic.
- Streamline tool loop logging output by removing tool call identifiers from execution and result events.

</details>