### PR TITLE
refactor: harden routing and tool execution

### DIFF
--- a/examples/config/acl.toml
+++ b/examples/config/acl.toml
@@ -19,9 +19,9 @@
 #   - kick_client: 踢出用户
 #   - ban_client: 封禁用户
 #   - move_client: 移动用户到指定频道
-#   - get_client_list: 获取在线用户列表
 #   - get_client_info: 获取用户详细信息
 #   - music_control: 音乐控制
+#   - web_search: 搜索最新网络信息
 
 [[rules]]
 name = "superadmin"
@@ -38,7 +38,6 @@ allowed_skills = [
   "poke_client",
   "send_message",
   "get_client_info",
-  "get_client_list",
   "music_control",
   "kick_client"
 ]
@@ -52,7 +51,6 @@ allowed_skills = [
   "poke_client",
   "send_message",
   "get_client_info",
-  "get_client_list",
   "music_control"
 ]
 can_target_admins = false
@@ -65,7 +63,6 @@ channel_group_ids = []
 allowed_skills = [
   "send_message",
   "get_client_info",
-  "get_client_list",
   "music_control"
 ]
 can_target_admins = false

--- a/examples/config/settings.toml
+++ b/examples/config/settings.toml
@@ -16,6 +16,7 @@ model = "gpt-4o"
 omni_model = false    # 多模态模型：true 时自动禁用 TTS/STT，直接使用语音输入输出
 max_context_turns = 3  # 最大上下文对话轮数（0 表示禁用上下文）
 max_context_sessions = 3  # 最大不同用户会话数（超过时淘汰最旧会话）
+max_concurrent_requests = 4  # 最大并发 LLM 请求数，必须大于 0
 
 # Headless 语音服务配置
 [headless]

--- a/proto/voice.proto
+++ b/proto/voice.proto
@@ -69,6 +69,7 @@ message ChatEvent {
   bool should_respond = 8;
   TargetMode reply_target_mode = 9;
   uint32 reply_target_client_id = 10;
+  uint32 invoker_client_id = 11;
 }
 
 message PlaybackEvent {

--- a/src/adapter/headless.rs
+++ b/src/adapter/headless.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -58,30 +58,22 @@ pub async fn run(
     let respond_private = config.bot_respond_to_private;
     let trigger_prefixes = config.bot_trigger_prefixes.clone();
     let default_reply = config.bot_default_reply_mode.clone();
-    let ts3_task = tokio::spawn(async move {
-        if let Err(e) = actor::ts3_actor(
-            ts3_client,
-            ts3_audio_rx,
-            ts3_notice_rx,
-            events_tx_clone,
-            ts3_shutdown,
-            respond_private,
-            trigger_prefixes,
-            default_reply,
-        )
-        .await
-        {
-            error!(%e, "ts3 actor exited");
-        }
-    });
+    let ts3_task = tokio::spawn(actor::ts3_actor(
+        ts3_client,
+        ts3_audio_rx,
+        ts3_notice_rx,
+        events_tx_clone,
+        ts3_shutdown,
+        respond_private,
+        trigger_prefixes,
+        default_reply,
+    ));
 
     let svc = voice_service::VoiceServiceImpl::new(
         ts3_audio_tx,
         ts3_notice_tx,
         events_tx,
-        config.bot_respond_to_private,
         config.bot_default_reply_mode.clone(),
-        config.bot_trigger_prefixes.clone(),
     );
 
     let addr: std::net::SocketAddr = match addr.parse() {
@@ -101,20 +93,12 @@ pub async fn run(
         .add_service(VoiceServiceServer::new(svc))
         .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown.cancelled());
 
-    tokio::select! {
-        result = server => {
-            if let Err(e) = result {
-                error!("gRPC server failed: {e:?}");
-            }
-        }
-        _ = shutdown.cancelled() => {}
-    }
-
-    if let Err(e) = ts3_task.await {
-        error!("Failed to wait for TS3 task: {e}");
-    }
-
-    Ok(())
+    let server_result = server.await.context("gRPC server failed");
+    ts3_task
+        .await
+        .context("failed to join TS3 actor")?
+        .context("TS3 actor failed")?;
+    server_result
 }
 
 pub struct Runtime {
@@ -132,9 +116,10 @@ impl Runtime {
         registry: Arc<SkillRegistry>,
         ts_adapter: Arc<crate::adapter::TsAdapter>,
     ) -> Self {
-        let voice_enabled = config.headless.stt.enabled || config.headless.tts.enabled;
+        let voice_enabled =
+            config.headless.stt.enabled || config.headless.tts.enabled || config.llm.omni_model;
         if !voice_enabled {
-            info!("headless: voice disabled (stt/tts not enabled), management-only mode");
+            info!("headless: voice disabled (stt/tts/omni not enabled), management-only mode");
             return Self {
                 shutdown: CancellationToken::new(),
                 service_handle: None,

--- a/src/adapter/headless/actor.rs
+++ b/src/adapter/headless/actor.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use dashmap::DashMap;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -23,16 +24,43 @@ pub async fn ts3_actor(
     let mut out_buf: VecDeque<(Vec<u8>, i32)> = VecDeque::with_capacity(400);
 
     let mut send_tick = tokio::time::interval(Duration::from_millis(20));
+    let client_names = Arc::new(DashMap::<i32, String>::new());
+
+    let enter_names = client_names.clone();
+    client.on_client_enter(Arc::new(move |event: tsclient_rs::Event| {
+        if let tsclient_rs::Event::ClientEnter(client) = event {
+            enter_names.insert(client.id, client.nickname);
+        }
+    }));
+
+    let leave_names = client_names.clone();
+    client.on_client_leave(Arc::new(move |event: tsclient_rs::Event| {
+        if let tsclient_rs::Event::ClientLeave(client) = event {
+            leave_names.remove(&client.id);
+        }
+    }));
 
     // voice data → AudioFrameEvent
     let events_tx_v = events_tx.clone();
+    let voice_names = client_names.clone();
     client.on_voice_data(Arc::new(move |event: tsclient_rs::Event| {
         if let tsclient_rs::Event::VoiceData(ref vd) = event {
+            let Ok(from_client_id) = u32::try_from(vd.client_id) else {
+                warn!(
+                    client_id = vd.client_id,
+                    "忽略调用者 ID 无效的 TeamSpeak 音频帧"
+                );
+                return;
+            };
+            let from_client_name = voice_names
+                .get(&vd.client_id)
+                .map(|name| name.clone())
+                .unwrap_or_default();
             let _ = events_tx_v.send(voicev1::Event {
                 unix_ms: now_unix_ms(),
                 payload: Some(voicev1::event::Payload::Audio(voicev1::AudioFrameEvent {
-                    from_client_id: vd.client_id as u32,
-                    from_client_name: String::new(),
+                    from_client_id,
+                    from_client_name,
                     codec: vd.codec,
                     is_whisper: false,
                     frame: vd.data.to_vec(),
@@ -48,9 +76,18 @@ pub async fn ts3_actor(
     client.on_text_message(Arc::new(move |event: tsclient_rs::Event| {
         if let tsclient_rs::Event::TextMessage(ref msg) = event {
             let target_mode = match msg.target_mode {
-                1 => 1, // private
-                2 => 2, // channel
-                _ => 3, // server
+                1..=3 => msg.target_mode,
+                mode => {
+                    warn!(target_mode = mode, "忽略未知类型的 TeamSpeak 文本消息");
+                    return;
+                }
+            };
+            let Ok(invoker_client_id) = u32::try_from(msg.invoker_id) else {
+                warn!(
+                    invoker_id = msg.invoker_id,
+                    "忽略调用者 ID 无效的 TeamSpeak 文本消息"
+                );
+                return;
             };
             let msg_content = msg.message.trim().to_string();
             let should_trigger_llm = (target_mode == 1 && respond_private)
@@ -58,12 +95,12 @@ pub async fn ts3_actor(
                     .iter()
                     .any(|prefix| msg_content.starts_with(prefix));
             let (reply_target_mode, reply_target_client_id) = if target_mode == 1 {
-                (1, msg.invoker_id as u32)
+                (1, invoker_client_id)
             } else {
                 match reply_mode.as_str() {
                     "channel" => (2, 0),
                     "server" => (3, 0),
-                    _ => (1, msg.invoker_id as u32),
+                    _ => (1, invoker_client_id),
                 }
             };
             let _ = events_tx_t.send(voicev1::Event {
@@ -79,10 +116,20 @@ pub async fn ts3_actor(
                     should_respond: should_trigger_llm,
                     reply_target_mode,
                     reply_target_client_id,
+                    invoker_client_id,
                 })),
             });
         }
     }));
+
+    match tsclient_rs::listClients(&client).await {
+        Ok(clients) => {
+            for client in clients {
+                client_names.insert(client.id, client.nickname);
+            }
+        }
+        Err(e) => warn!("初始化 TeamSpeak 客户端名称缓存失败: {e}"),
+    }
 
     loop {
         tokio::select! {

--- a/src/adapter/headless/event.rs
+++ b/src/adapter/headless/event.rs
@@ -24,6 +24,19 @@ fn check_ts_error(err: tsclient_rs::Error, op: &str) -> anyhow::Error {
     anyhow!("{op} failed: {err}")
 }
 
+fn checked_client_id(clid: u32) -> Result<i32> {
+    i32::try_from(clid).map_err(|_| anyhow!("TeamSpeak client ID out of range: {clid}"))
+}
+
+fn parse_client_channel_group_id(info: &std::collections::HashMap<String, String>) -> Result<u32> {
+    let value = info
+        .get("client_channel_group_id")
+        .ok_or_else(|| anyhow!("clientinfo missing client_channel_group_id"))?;
+    value
+        .parse()
+        .map_err(|error| anyhow!("invalid client_channel_group_id '{value}': {error}"))
+}
+
 /// 封装 tsclient-rs::Client，提供管理命令和事件订阅。
 /// 共享的 `Arc<Client>` 可通过 `get_client()` 给 voice 模块使用。
 pub struct TsAdapter {
@@ -109,12 +122,14 @@ impl TsAdapter {
                     }
 
                     let clid = client.client_id();
+                    let bot_clid = u32::try_from(clid)
+                        .map_err(|_| anyhow!("invalid TeamSpeak bot client ID: {clid}"))?;
                     let client = Arc::new(client);
 
                     return Ok(Arc::new(Self {
                         client,
                         event_tx,
-                        bot_clid: std::sync::atomic::AtomicU32::new(clid as u32),
+                        bot_clid: std::sync::atomic::AtomicU32::new(bot_clid),
                     }));
                 }
                 Ok(Err(e)) => {
@@ -139,15 +154,27 @@ impl TsAdapter {
             let tx = tx.clone();
             client.on_text_message(Arc::new(move |event: tsclient_rs::Event| {
                 if let tsclient_rs::Event::TextMessage(ref msg) = event {
+                    let target_mode = match msg.target_mode {
+                        1 => TextMessageTarget::Private,
+                        2 => TextMessageTarget::Channel,
+                        3 => TextMessageTarget::Server,
+                        mode => {
+                            warn!(target_mode = mode, "忽略未知类型的 TeamSpeak 文本消息");
+                            return;
+                        }
+                    };
+                    let Ok(invoker_id) = u32::try_from(msg.invoker_id) else {
+                        warn!(
+                            invoker_id = msg.invoker_id,
+                            "忽略调用者 ID 无效的 TeamSpeak 文本消息"
+                        );
+                        return;
+                    };
                     let _ = tx.send(TsEvent::TextMessage(TextMessageEvent {
-                        target_mode: match msg.target_mode {
-                            1 => TextMessageTarget::Private,
-                            2 => TextMessageTarget::Channel,
-                            _ => TextMessageTarget::Server,
-                        },
+                        target_mode,
                         invoker_name: msg.invoker_name.clone(),
                         invoker_uid: msg.invoker_uid.clone(),
-                        invoker_id: msg.invoker_id as u32,
+                        invoker_id,
                         invoker_groups: msg.invoker_groups.clone(),
                         message: msg.message.clone(),
                     }));
@@ -227,7 +254,7 @@ impl TsAdapter {
     }
 
     pub async fn poke(&self, clid: u32, msg: &str) -> Result<()> {
-        tsclient_rs::poke(&self.client, clid as i32, msg)
+        tsclient_rs::poke(&self.client, checked_client_id(clid)?, msg)
             .await
             .map_err(|e| anyhow!("poke failed: {e}"))
     }
@@ -235,7 +262,7 @@ impl TsAdapter {
     pub async fn kick(&self, clid: u32, reason: &str) -> Result<()> {
         tsclient_rs::clientKick(
             &self.client,
-            clid as i32,
+            checked_client_id(clid)?,
             tsclient_rs::KickReason::Server,
             reason,
         )
@@ -244,15 +271,20 @@ impl TsAdapter {
     }
 
     pub async fn ban(&self, clid: u32, time_secs: u64, reason: &str) -> Result<()> {
-        tsclient_rs::banClient(&self.client, clid as i32, time_secs, reason)
+        tsclient_rs::banClient(&self.client, checked_client_id(clid)?, time_secs, reason)
             .await
             .map_err(|e| anyhow!("banClient failed: {e}"))
     }
 
     pub async fn move_client(&self, clid: u32, channel_id: u32) -> Result<()> {
-        tsclient_rs::clientMove(&self.client, clid as i32, channel_id as u64, "")
-            .await
-            .map_err(|e| anyhow!("clientMove failed: {e}"))
+        tsclient_rs::clientMove(
+            &self.client,
+            checked_client_id(clid)?,
+            u64::from(channel_id),
+            "",
+        )
+        .await
+        .map_err(|e| anyhow!("clientMove failed: {e}"))
     }
 
     pub async fn list_channels(&self) -> Result<Vec<tsclient_rs::ChannelInfo>> {
@@ -271,9 +303,14 @@ impl TsAdapter {
         &self,
         clid: u32,
     ) -> Result<std::collections::HashMap<String, String>> {
-        tsclient_rs::getClientInfo(&self.client, clid as i32)
+        tsclient_rs::getClientInfo(&self.client, checked_client_id(clid)?)
             .await
             .map_err(|e| anyhow!("getClientInfo failed: {e}"))
+    }
+
+    pub async fn get_client_channel_group_id(&self, clid: u32) -> Result<u32> {
+        let info = self.get_client_info(clid).await?;
+        parse_client_channel_group_id(&info)
     }
 
     pub async fn quit(&self) -> Result<()> {
@@ -304,4 +341,29 @@ pub enum TextMessageTarget {
     Private,
     Channel,
     Server,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_client_channel_group_id;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parses_nonzero_client_channel_group_id() {
+        let info = HashMap::from([("client_channel_group_id".to_string(), "42".to_string())]);
+
+        assert_eq!(parse_client_channel_group_id(&info).unwrap(), 42);
+    }
+
+    #[test]
+    fn rejects_missing_client_channel_group_id() {
+        assert!(parse_client_channel_group_id(&HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_client_channel_group_id() {
+        let info = HashMap::from([("client_channel_group_id".to_string(), "invalid".to_string())]);
+
+        assert!(parse_client_channel_group_id(&info).is_err());
+    }
 }

--- a/src/adapter/headless/speech.rs
+++ b/src/adapter/headless/speech.rs
@@ -217,7 +217,7 @@ impl OpenAiSpeechProvider {
             "sending stt request"
         );
 
-        let api_key = fallback_str(&stt.api_key, &self.config.llm.api_key);
+        let api_key = resolve_speech_api_key(&stt.api_key, &stt.base_url, &self.config.llm.api_key);
 
         let mut form = Form::new();
         if !stt.model.is_empty() {
@@ -234,13 +234,11 @@ impl OpenAiSpeechProvider {
                 .context("set wav mime failed")?,
         );
 
-        let resp = self
-            .client
-            .post(url)
-            .header("Authorization", format!("Bearer {api_key}"))
-            .multipart(form)
-            .send()
-            .await?;
+        let mut request = self.client.post(url).multipart(form);
+        if !api_key.is_empty() {
+            request = request.bearer_auth(api_key);
+        }
+        let resp = request.send().await?;
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
             return Err(anyhow!("stt request failed: {err}"));
@@ -265,7 +263,7 @@ impl OpenAiSpeechProvider {
             return Err(anyhow!("tts disabled"));
         }
 
-        let api_key = fallback_str(&tts.api_key, &self.config.llm.api_key);
+        let api_key = resolve_speech_api_key(&tts.api_key, &tts.base_url, &self.config.llm.api_key);
 
         // MiMo TTS: uses /chat/completions with audio field
         if tts.provider == "mimo" {
@@ -287,13 +285,11 @@ impl OpenAiSpeechProvider {
             "response_format": "mp3",
         });
 
-        let resp = self
-            .client
-            .post(url)
-            .header("Authorization", format!("Bearer {api_key}"))
-            .json(&body)
-            .send()
-            .await?;
+        let mut request = self.client.post(url).json(&body);
+        if !api_key.is_empty() {
+            request = request.bearer_auth(api_key);
+        }
+        let resp = request.send().await?;
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
@@ -337,13 +333,11 @@ impl OpenAiSpeechProvider {
             }
         });
 
-        let resp = self
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .json(&body)
-            .send()
-            .await?;
+        let mut request = self.client.post(&url).json(&body);
+        if !api_key.is_empty() {
+            request = request.bearer_auth(api_key);
+        }
+        let resp = request.send().await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -437,11 +431,17 @@ fn downsample_48k_stereo_to_16k_mono(stereo: &[i16]) -> Vec<i16> {
     mono_16k
 }
 
-fn fallback_str<'a>(value: &'a str, fallback: &'a str) -> &'a str {
-    if value.is_empty() {
-        fallback
+fn resolve_speech_api_key<'a>(
+    service_api_key: &'a str,
+    service_base_url: &str,
+    llm_api_key: &'a str,
+) -> &'a str {
+    if !service_api_key.is_empty() {
+        service_api_key
+    } else if service_base_url.is_empty() {
+        llm_api_key
     } else {
-        value
+        ""
     }
 }
 
@@ -627,4 +627,30 @@ pub fn is_speakable(text: &str) -> bool {
         .filter(|c| matches!(c, '+' | '/' | '='))
         .count();
     garbled_chars == 0 || total <= 8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_speech_api_key;
+
+    #[test]
+    fn explicit_speech_endpoint_does_not_inherit_llm_key() {
+        assert_eq!(
+            resolve_speech_api_key("", "https://speech.example/v1", "llm-secret"),
+            ""
+        );
+    }
+
+    #[test]
+    fn llm_endpoint_fallback_inherits_llm_key() {
+        assert_eq!(resolve_speech_api_key("", "", "llm-secret"), "llm-secret");
+    }
+
+    #[test]
+    fn explicit_speech_key_takes_precedence() {
+        assert_eq!(
+            resolve_speech_api_key("speech-secret", "https://speech.example/v1", "llm-secret"),
+            "speech-secret"
+        );
+    }
 }

--- a/src/adapter/headless/voice_service.rs
+++ b/src/adapter/headless/voice_service.rs
@@ -19,9 +19,7 @@ pub struct VoiceServiceImpl {
     ts3_audio_tx: mpsc::Sender<(Vec<u8>, i32)>,
     ts3_notice_tx: mpsc::Sender<(i32, u32, String)>,
     events_tx: broadcast::Sender<voicev1::Event>,
-    bot_respond_to_private: bool,
     bot_default_reply_mode: String,
-    bot_trigger_prefixes: Vec<String>,
     tts_stream_lock: tokio::sync::Mutex<()>,
 }
 
@@ -30,17 +28,13 @@ impl VoiceServiceImpl {
         ts3_audio_tx: mpsc::Sender<(Vec<u8>, i32)>,
         ts3_notice_tx: mpsc::Sender<(i32, u32, String)>,
         events_tx: broadcast::Sender<voicev1::Event>,
-        bot_respond_to_private: bool,
         bot_default_reply_mode: String,
-        bot_trigger_prefixes: Vec<String>,
     ) -> Self {
         Self {
             ts3_audio_tx,
             ts3_notice_tx,
             events_tx,
-            bot_respond_to_private,
             bot_default_reply_mode,
-            bot_trigger_prefixes,
             tts_stream_lock: tokio::sync::Mutex::new(()),
         }
     }
@@ -157,17 +151,17 @@ async fn stream_tts_audio_loop(
             }
         };
 
-        if let Err(e) = stdin.write_all(&chunk.payload).await {
-            warn!("write ffmpeg stdin failed: {e}, skipping chunk");
-            continue;
-        }
-        drop(stdin);
-
         let mut stdout = child
             .child
             .as_mut()
             .and_then(|c| c.stdout.take())
             .ok_or_else(|| anyhow!("ffmpeg stdout missing"))?;
+        let payload = chunk.payload;
+        let stdin_task = tokio::spawn(async move {
+            let result = stdin.write_all(&payload).await;
+            drop(stdin);
+            result
+        });
 
         let mut pcm = vec![0u8; frame_bytes];
         let mut float_buf = vec![0f32; frame_samples_per_channel * 2];
@@ -206,10 +200,12 @@ async fn stream_tts_audio_loop(
             let _ = c.start_kill();
             let _ = c.wait().await;
         }
-    }
 
-    if let Err(e) = ts3_audio_tx.send((vec![], 5)).await {
-        warn!("send stream_tts eos failed: {e}");
+        match stdin_task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!("write ffmpeg stdin failed: {e}"),
+            Err(e) => warn!("ffmpeg stdin task failed: {e}"),
+        }
     }
 
     Ok(())
@@ -245,12 +241,6 @@ impl VoiceService for VoiceServiceImpl {
         let mut target = r.target_client_id;
 
         if mode == 1 {
-            if !self.bot_respond_to_private {
-                return Ok(Response::new(voicev1::CommandResponse {
-                    ok: false,
-                    message: "private reply disabled by bot.respond_to_private".to_string(),
-                }));
-            }
             if target == 0 {
                 return Ok(Response::new(voicev1::CommandResponse {
                     ok: false,
@@ -276,10 +266,8 @@ impl VoiceService for VoiceServiceImpl {
             &self.events_tx,
             2,
             format!(
-                "send_notice accepted: target_mode={} target_client_id={} trigger_prefixes={}",
-                mode,
-                target,
-                self.bot_trigger_prefixes.len()
+                "send_notice accepted: target_mode={} target_client_id={}",
+                mode, target
             ),
         );
 

--- a/src/adapter/napcat/event.rs
+++ b/src/adapter/napcat/event.rs
@@ -27,22 +27,11 @@ pub struct GroupMessageEvent {
     pub timestamp: u64,
 }
 
-impl PrivateMessageEvent {
-    pub fn timestamp() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-    }
-}
-
-impl GroupMessageEvent {
-    pub fn timestamp() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-    }
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[derive(Debug, Deserialize)]
@@ -53,6 +42,7 @@ struct RawEvent {
     user_id: Option<i64>,
     message: Option<Value>,
     sender: Option<Value>,
+    time: Option<u64>,
 }
 
 pub fn parse_event(raw: Value) -> NcEvent {
@@ -69,24 +59,32 @@ pub fn parse_event(raw: Value) -> NcEvent {
 }
 
 fn parse_message_event(ev: RawEvent) -> NcEvent {
-    let user_id = ev.user_id.unwrap_or(0);
+    let Some(user_id) = ev.user_id else {
+        return NcEvent::Heartbeat;
+    };
     let message = parse_segments(ev.message.as_ref().unwrap_or(&Value::Array(vec![])));
     let sender = parse_sender(ev.sender.as_ref().unwrap_or(&Value::Null), user_id);
+    let timestamp = ev.time.unwrap_or_else(now_unix_seconds);
 
     match ev.message_type.as_deref() {
         Some("private") => NcEvent::PrivateMessage(PrivateMessageEvent {
             user_id,
             message,
             sender,
-            timestamp: PrivateMessageEvent::timestamp(),
+            timestamp,
         }),
-        Some("group") => NcEvent::GroupMessage(GroupMessageEvent {
-            group_id: ev.group_id.unwrap_or(0),
-            user_id,
-            message,
-            sender,
-            timestamp: GroupMessageEvent::timestamp(),
-        }),
+        Some("group") => {
+            let Some(group_id) = ev.group_id else {
+                return NcEvent::Heartbeat;
+            };
+            NcEvent::GroupMessage(GroupMessageEvent {
+                group_id,
+                user_id,
+                message,
+                sender,
+                timestamp,
+            })
+        }
         _ => NcEvent::Heartbeat,
     }
 }

--- a/src/adapter/napcat/ws.rs
+++ b/src/adapter/napcat/ws.rs
@@ -33,6 +33,17 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
+async fn wait_for_retry_or_closed(rx: &mut mpsc::Receiver<()>, delay: Duration) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => true,
+        message = rx.recv() => message.is_some(),
+    }
+}
+
+fn parse_ws_url(value: &str) -> Result<url::Url> {
+    url::Url::parse(value).map_err(|_| anyhow::anyhow!("Invalid NapCat WebSocket URL"))
+}
+
 pub struct NapCatAdapter {
     writer: Mutex<Option<WsSink>>,
     event_tx: broadcast::Sender<NcEvent>,
@@ -78,28 +89,33 @@ impl NapCatAdapter {
     }
 
     async fn reconnect_loop(weak: std::sync::Weak<NapCatAdapter>, mut rx: mpsc::Receiver<()>) {
-        const MAX_RETRIES: u32 = 10;
         while rx.recv().await.is_some() {
             let Some(adapter) = weak.upgrade() else { break };
             info!("NapCat reconnecting...");
             *adapter.writer.lock().await = None;
+            drop(adapter);
 
             let mut delay = Duration::from_secs(1);
-            for attempt in 0..MAX_RETRIES {
-                match Self::do_reconnect(&adapter).await {
+            let mut attempt = 1u32;
+            loop {
+                let Some(adapter) = weak.upgrade() else {
+                    return;
+                };
+                let result = Self::do_reconnect(&adapter).await;
+                drop(adapter);
+
+                match result {
                     Ok(()) => {
                         info!("NapCat reconnected");
                         break;
                     }
                     Err(e) => {
-                        warn!(
-                            "[{}/{}] NapCat reconnect failed: {}",
-                            attempt + 1,
-                            MAX_RETRIES,
-                            e
-                        );
-                        tokio::time::sleep(delay).await;
+                        warn!("[{attempt}] NapCat reconnect failed: {e}");
+                        if !wait_for_retry_or_closed(&mut rx, delay).await {
+                            return;
+                        }
                         delay = (delay * 2).min(Duration::from_secs(60));
+                        attempt = attempt.saturating_add(1);
                     }
                 }
             }
@@ -170,35 +186,30 @@ impl NapCatAdapter {
         broadcast::Sender<NcEvent>,
         Arc<DashMap<String, oneshot::Sender<NcApiResponse>>>,
     )> {
-        let url = &config.ws_url;
-        info!("Connecting to NapCat at {url}");
-
-        let mut req = url
-            .clone()
-            .into_client_request()
-            .map_err(|e| anyhow::anyhow!("Invalid WS URL '{}': {}", url, e))?;
+        let mut url = parse_ws_url(&config.ws_url)?;
+        info!("Connecting to NapCat WebSocket");
 
         if !config.access_token.is_empty() {
-            // Header 认证
+            url.query_pairs_mut()
+                .append_pair("access_token", &config.access_token);
+        }
+        let mut req = url
+            .as_str()
+            .into_client_request()
+            .map_err(|_| anyhow::anyhow!("Failed to build NapCat WebSocket request"))?;
+
+        if !config.access_token.is_empty() {
             let bearer = format!("Bearer {}", config.access_token);
             req.headers_mut().insert(
                 AUTHORIZATION,
                 HeaderValue::from_str(&bearer)
                     .map_err(|e| anyhow::anyhow!("Invalid access_token: {e}"))?,
             );
-
-            // Query param 兼容 OneBot 11 标准
-            let uri = req.uri();
-            let sep = if uri.query().is_some() { "&" } else { "?" };
-            let new_uri = format!("{}{}access_token={}", uri, sep, &config.access_token);
-            *req.uri_mut() = new_uri
-                .parse()
-                .map_err(|e| anyhow::anyhow!("Failed to build URI: {e}"))?;
         }
 
         let (ws_stream, _) = connect_async_tls_with_config(req, None, false, None)
             .await
-            .map_err(|e| anyhow::anyhow!("NapCat WS handshake failed: {e}"))?;
+            .map_err(|_| anyhow::anyhow!("NapCat WebSocket handshake failed"))?;
 
         let (tx, _) = broadcast::channel::<NcEvent>(256);
         let pending: Arc<DashMap<String, oneshot::Sender<NcApiResponse>>> =
@@ -338,5 +349,27 @@ impl NapCatAdapter {
 
     pub fn subscribe(&self) -> broadcast::Receiver<NcEvent> {
         self.event_tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_wait_stops_when_adapter_channel_closes() {
+        let (tx, mut rx) = mpsc::channel(1);
+        drop(tx);
+
+        assert!(!wait_for_retry_or_closed(&mut rx, Duration::from_secs(60)).await);
+    }
+
+    #[test]
+    fn invalid_ws_url_error_does_not_echo_credentials() {
+        let secret = "secret-token";
+        let error =
+            parse_ws_url(&format!("://user:{secret}@host/path?access_token={secret}")).unwrap_err();
+
+        assert!(!error.to_string().contains(secret));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ pub fn config_dir() -> PathBuf {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct AppConfig {
     pub llm: LlmConfig,
     pub bot: BotConfig,
@@ -66,6 +67,27 @@ impl AppConfig {
     }
 
     pub fn validate(&self) -> Result<()> {
+        if self.llm.model.trim().is_empty() {
+            anyhow::bail!("llm.model must not be empty");
+        }
+
+        let llm_base_url =
+            url::Url::parse(&self.llm.base_url).context("llm.base_url must be a valid URL")?;
+        if !matches!(llm_base_url.scheme(), "http" | "https") {
+            anyhow::bail!("llm.base_url must use http or https");
+        }
+
+        if self.llm.max_concurrent_requests == 0 {
+            anyhow::bail!("llm.max_concurrent_requests must be greater than zero");
+        }
+
+        if !matches!(
+            self.bot.default_reply_mode.as_str(),
+            "private" | "channel" | "server"
+        ) {
+            anyhow::bail!("bot.default_reply_mode must be private, channel, or server");
+        }
+
         if let Some(ref mc) = self.music_backend {
             if !VALID_BACKENDS.contains(&mc.backend.as_str()) {
                 anyhow::bail!(
@@ -87,5 +109,60 @@ impl AppConfig {
         let config: AppConfig = toml::from_str(&content)?;
         config.validate()?;
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_llm_section_uses_new_concurrency_default() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[llm]
+api_key = "legacy-key"
+base_url = "http://127.0.0.1:11434/v1"
+model = "legacy-model"
+omni_model = true
+max_context_turns = 3
+max_context_sessions = 8
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.llm.api_key, "legacy-key");
+        assert_eq!(config.llm.base_url, "http://127.0.0.1:11434/v1");
+        assert_eq!(config.llm.model, "legacy-model");
+        assert!(config.llm.omni_model);
+        assert_eq!(config.llm.max_context_turns, 3);
+        assert_eq!(config.llm.max_context_sessions, 8);
+        assert_eq!(config.llm.max_concurrent_requests, 4);
+        assert_eq!(config.bot.default_reply_mode, "private");
+        assert!(!config.napcat.enabled);
+        assert_eq!(config.logging.max_log_days, 7);
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_zero_llm_concurrency() {
+        let mut config = AppConfig::default();
+        config.llm.max_concurrent_requests = 0;
+
+        let error = config.validate().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("max_concurrent_requests must be greater than zero"));
+    }
+
+    #[test]
+    fn rejects_invalid_reply_mode() {
+        let mut config = AppConfig::default();
+        config.bot.default_reply_mode = "invalid".to_string();
+
+        let error = config.validate().unwrap_err();
+
+        assert!(error.to_string().contains("default_reply_mode"));
     }
 }

--- a/src/config/bot.rs
+++ b/src/config/bot.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct BotConfig {
     #[serde(default = "default_bot_nickname")]
     pub nickname: String,

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct LlmConfig {
     pub api_key: String,
     pub base_url: String,
@@ -14,10 +15,17 @@ pub struct LlmConfig {
     /// 最大会话数（0 表示不限制）
     #[serde(default = "default_max_context_sessions")]
     pub max_context_sessions: usize,
+    /// 最大并发 LLM 请求数
+    #[serde(default = "default_max_concurrent_requests")]
+    pub max_concurrent_requests: usize,
 }
 
 fn default_max_context_sessions() -> usize {
     1000
+}
+
+fn default_max_concurrent_requests() -> usize {
+    4
 }
 
 impl Default for LlmConfig {
@@ -29,6 +37,7 @@ impl Default for LlmConfig {
             omni_model: false,
             max_context_turns: 0,
             max_context_sessions: 1000,
+            max_concurrent_requests: default_max_concurrent_requests(),
         }
     }
 }

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct LogConfig {
     pub file_level: String,
     pub max_log_days: u32,

--- a/src/config/napcat.rs
+++ b/src/config/napcat.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 /// - `trusted_groups`: 信任的群 ID 列表，群内所有成员可使用机器人
 /// - `trusted_users`: 信任的用户 QQ 号列表，私聊和群聊均可使用
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct NapCatConfig {
     /// 是否启用 NapCat 适配器
     pub enabled: bool,

--- a/src/config/prompts.rs
+++ b/src/config/prompts.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct PromptsConfig {
     pub system: SystemPrompts,
     pub tts: TtsPrompts,
@@ -18,6 +19,7 @@ impl Default for PromptsConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct SystemPrompts {
     pub content: String,
 }
@@ -31,6 +33,7 @@ impl Default for SystemPrompts {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(default)]
 pub struct TtsPrompts {
     /// MiMo TTS 风格提示，用于控制语音的语调、语速、情感等
     pub style_prompt: String,

--- a/src/llm/context.rs
+++ b/src/llm/context.rs
@@ -1,28 +1,27 @@
-use dashmap::DashMap;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::sync::Arc;
+use std::sync::Mutex;
 
 /// 会话来源
 #[derive(Debug, Clone)]
 pub enum SessionSource {
     /// TeamSpeak 客户端
-    TeamSpeak { clid: u32 },
+    TeamSpeak { uid: String },
     /// NapCat 私聊
     NapCatPrivate { user_id: i64 },
     /// NapCat 群聊
     NapCatGroup { group_id: i64 },
     /// Headless 模式
-    Headless { caller_id: u32 },
+    Headless { uid: String },
 }
 
 impl fmt::Display for SessionSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SessionSource::TeamSpeak { clid } => write!(f, "sq:{}", clid),
+            SessionSource::TeamSpeak { uid } => write!(f, "sq:{}", uid),
             SessionSource::NapCatPrivate { user_id } => write!(f, "nc:private:{}", user_id),
             SessionSource::NapCatGroup { group_id } => write!(f, "nc:group:{}", group_id),
-            SessionSource::Headless { caller_id } => write!(f, "headless:{}", caller_id),
+            SessionSource::Headless { uid } => write!(f, "headless:{}", uid),
         }
     }
 }
@@ -36,21 +35,23 @@ pub struct ContextTurn {
 
 /// 上下文窗口管理器
 pub struct ContextWindow {
-    /// 会话历史，key = session_id
-    histories: Arc<DashMap<String, VecDeque<ContextTurn>>>,
-    /// 会话创建顺序（用于淘汰最旧会话）
-    session_order: Arc<std::sync::Mutex<VecDeque<String>>>,
+    state: Mutex<ContextState>,
     /// 最大对话轮数
     max_turns: usize,
     /// 最大会话数
     max_sessions: usize,
 }
 
+#[derive(Default)]
+struct ContextState {
+    histories: HashMap<String, VecDeque<ContextTurn>>,
+    session_order: VecDeque<String>,
+}
+
 impl ContextWindow {
     pub fn new(max_turns: usize, max_sessions: usize) -> Self {
         Self {
-            histories: Arc::new(DashMap::new()),
-            session_order: Arc::new(std::sync::Mutex::new(VecDeque::new())),
+            state: Mutex::new(ContextState::default()),
             max_turns,
             max_sessions,
         }
@@ -68,25 +69,25 @@ impl ContextWindow {
         }
 
         let session_id = source.to_string();
+        let mut state = self.state.lock().expect("context window lock poisoned");
 
-        // 检查是否需要淘汰旧会话
-        if self.max_sessions > 0 {
-            let mut order = self.session_order.lock().unwrap();
-            if !order.contains(&session_id) {
-                // 新会话，检查是否超过限制
-                while order.len() >= self.max_sessions {
-                    if let Some(old_id) = order.pop_front() {
-                        self.histories.remove(&old_id);
-                    }
-                }
-                order.push_back(session_id.clone());
+        if self.max_sessions > 0 && !state.histories.contains_key(&session_id) {
+            while state.histories.len() >= self.max_sessions {
+                let old_id = state
+                    .session_order
+                    .pop_front()
+                    .expect("context session order is inconsistent");
+                state
+                    .histories
+                    .remove(&old_id)
+                    .expect("context session history is inconsistent");
             }
+            state.session_order.push_back(session_id.clone());
         }
 
-        let mut entry = self.histories.entry(session_id).or_default();
+        let entry = state.histories.entry(session_id).or_default();
         entry.push_back(turn);
 
-        // 裁剪超出限制的旧对话
         while entry.len() > self.max_turns {
             entry.pop_front();
         }
@@ -95,9 +96,68 @@ impl ContextWindow {
     /// 获取会话历史
     pub fn get(&self, source: &SessionSource) -> Vec<ContextTurn> {
         let session_id = source.to_string();
-        self.histories
+        self.state
+            .lock()
+            .expect("context window lock poisoned")
+            .histories
             .get(&session_id)
             .map(|v| v.iter().cloned().collect())
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn turn(value: usize) -> ContextTurn {
+        ContextTurn {
+            user: format!("user-{value}"),
+            assistant: format!("assistant-{value}"),
+        }
+    }
+
+    #[test]
+    fn keeps_only_the_configured_turn_count() {
+        let context = ContextWindow::new(2, 10);
+        let source = SessionSource::TeamSpeak {
+            uid: "uid-1".to_string(),
+        };
+
+        context.push(&source, turn(1));
+        context.push(&source, turn(2));
+        context.push(&source, turn(3));
+
+        let history = context.get(&source);
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].user, "user-2");
+        assert_eq!(history[1].user, "user-3");
+    }
+
+    #[test]
+    fn concurrent_writes_respect_the_session_limit() {
+        let context = Arc::new(ContextWindow::new(1, 4));
+        let mut threads = Vec::new();
+
+        for caller_id in 0..64 {
+            let context = context.clone();
+            threads.push(std::thread::spawn(move || {
+                context.push(
+                    &SessionSource::Headless {
+                        uid: format!("uid-{caller_id}"),
+                    },
+                    turn(caller_id as usize),
+                );
+            }));
+        }
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        let state = context.state.lock().unwrap();
+        assert_eq!(state.histories.len(), 4);
+        assert_eq!(state.histories.len(), state.session_order.len());
     }
 }

--- a/src/llm/engine.rs
+++ b/src/llm/engine.rs
@@ -7,10 +7,12 @@ use crate::llm::tool_loop::{
 use anyhow::Result;
 use serde_json::{json, Value};
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 pub struct LlmEngine {
     provider: Box<dyn LlmProvider>,
     context: ContextWindow,
+    request_limit: Semaphore,
 }
 
 impl LlmEngine {
@@ -18,7 +20,12 @@ impl LlmEngine {
         let cfg = &config;
         let provider = Box::new(OpenAiProvider::new(cfg.llm.clone()));
         let context = ContextWindow::new(cfg.llm.max_context_turns, cfg.llm.max_context_sessions);
-        Self { provider, context }
+        let request_limit = Semaphore::new(cfg.llm.max_concurrent_requests);
+        Self {
+            provider,
+            context,
+            request_limit,
+        }
     }
 
     pub async fn run_tool_loop(
@@ -28,6 +35,11 @@ impl LlmEngine {
         executor: &dyn ToolExecutor,
         callbacks: Option<&StreamCallbacks>,
     ) -> Result<ToolLoopResult, ToolLoopError> {
+        let _permit = self
+            .request_limit
+            .acquire()
+            .await
+            .map_err(|error| anyhow::anyhow!("LLM request limit closed: {error}"))?;
         run_tool_loop(messages, tools, self.provider.as_ref(), executor, callbacks).await
     }
 

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -4,11 +4,15 @@ use async_trait::async_trait;
 use futures_util::stream::BoxStream;
 use futures_util::StreamExt;
 use reqwest::Client;
+use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+
+pub(crate) const MAX_TOOL_CALLS_PER_TURN: usize = 8;
+pub(crate) const MAX_TOOL_ARGUMENT_BYTES_TOTAL: usize = 64 * 1024;
 
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
@@ -33,6 +37,98 @@ pub enum LlmStreamEvent {
         finish_reason: String,
         tool_calls: Vec<ToolCall>,
     },
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionChunk {
+    #[serde(default)]
+    choices: Vec<ChunkChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkChoice {
+    #[serde(default)]
+    delta: ChunkDelta,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ChunkDelta {
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<ToolCallDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallDelta {
+    index: usize,
+    id: Option<String>,
+    function: Option<FunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FunctionDelta {
+    name: Option<String>,
+    arguments: Option<String>,
+}
+
+#[derive(Default)]
+struct ToolCallBuilder {
+    id: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+fn merge_tool_call_delta(
+    builders: &mut BTreeMap<usize, ToolCallBuilder>,
+    tool_call: ToolCallDelta,
+) -> Result<()> {
+    let index = tool_call.index;
+    if !builders.contains_key(&index) && builders.len() >= MAX_TOOL_CALLS_PER_TURN {
+        anyhow::bail!("tool call count exceeds the per-turn limit of {MAX_TOOL_CALLS_PER_TURN}");
+    }
+
+    let incoming_argument_bytes = tool_call
+        .function
+        .as_ref()
+        .and_then(|function| function.arguments.as_ref())
+        .map_or(0, String::len);
+    let accumulated_argument_bytes = builders
+        .values()
+        .try_fold(0usize, |total, builder| {
+            total.checked_add(builder.arguments.len())
+        })
+        .ok_or_else(|| anyhow::anyhow!("tool argument byte count overflowed"))?;
+    let next_argument_bytes = accumulated_argument_bytes
+        .checked_add(incoming_argument_bytes)
+        .ok_or_else(|| anyhow::anyhow!("tool argument byte count overflowed"))?;
+    if next_argument_bytes > MAX_TOOL_ARGUMENT_BYTES_TOTAL {
+        anyhow::bail!(
+            "tool arguments exceed the total byte limit of {MAX_TOOL_ARGUMENT_BYTES_TOTAL}"
+        );
+    }
+
+    let entry = builders.entry(index).or_default();
+    if let Some(id) = tool_call.id.filter(|value| !value.is_empty()) {
+        if entry.id.replace(id.clone()).is_some_and(|old| old != id) {
+            anyhow::bail!("conflicting IDs for tool call index {index}");
+        }
+    }
+    if let Some(function) = tool_call.function {
+        if let Some(name) = function.name.filter(|value| !value.is_empty()) {
+            if entry
+                .name
+                .replace(name.clone())
+                .is_some_and(|old| old != name)
+            {
+                anyhow::bail!("conflicting names for tool call index {index}");
+            }
+        }
+        if let Some(arguments) = function.arguments {
+            entry.arguments.push_str(&arguments);
+        }
+    }
+    Ok(())
 }
 
 pub struct OpenAiProvider {
@@ -83,16 +179,14 @@ impl LlmProvider for OpenAiProvider {
             .await?;
 
         if !resp.status().is_success() {
-            let error_text = resp.text().await.unwrap_or_default();
-            return Err(anyhow::anyhow!("LLM API error: {}", error_text).into());
+            return Err(anyhow::anyhow!("LLM API error: HTTP {}", resp.status()).into());
         }
 
         let mut byte_stream = resp.bytes_stream();
         let (tx, rx) = mpsc::channel::<Result<LlmStreamEvent>>(128);
         tokio::spawn(async move {
             let mut pending: Vec<u8> = Vec::new();
-            let mut tool_call_builders: BTreeMap<usize, (Option<String>, Option<String>, String)> =
-                BTreeMap::new();
+            let mut tool_call_builders: BTreeMap<usize, ToolCallBuilder> = BTreeMap::new();
 
             while let Some(item) = byte_stream.next().await {
                 let bytes = match item {
@@ -121,66 +215,58 @@ impl LlmProvider for OpenAiProvider {
                             return;
                         }
                     };
-                    if line.is_empty() || !line.starts_with("data: ") {
+                    let Some(payload) = line.strip_prefix("data:") else {
+                        continue;
+                    };
+                    let payload = payload.trim_start();
+                    if payload.is_empty() {
                         continue;
                     }
-                    let payload = line.trim_start_matches("data: ").trim();
                     if payload == "[DONE]" {
-                        let tool_calls = finalize_tool_calls(&mut tool_call_builders);
                         let _ = tx
-                            .send(Ok(LlmStreamEvent::Done {
-                                finish_reason: "stop".to_string(),
-                                tool_calls,
-                            }))
+                            .send(Err(anyhow::anyhow!(
+                                "LLM stream ended without a finish reason"
+                            )))
                             .await;
                         return;
                     }
-                    let event: Value = match serde_json::from_str(payload) {
+                    let event: ChatCompletionChunk = match serde_json::from_str(payload) {
                         Ok(v) => v,
                         Err(e) => {
                             let _ = tx.send(Err(e.into())).await;
                             return;
                         }
                     };
-                    if let Some(content) = event["choices"][0]["delta"]["content"].as_str() {
+                    let Some(choice) = event.choices.into_iter().next() else {
+                        continue;
+                    };
+                    if let Some(content) = choice.delta.content {
                         if !content.is_empty() {
-                            let _ = tx
-                                .send(Ok(LlmStreamEvent::Token(content.to_string())))
-                                .await;
-                        }
-                    }
-                    if let Some(tool_calls) = event["choices"][0]["delta"]["tool_calls"].as_array()
-                    {
-                        for tc in tool_calls {
-                            let index = tc["index"].as_i64().unwrap_or(0) as usize;
-                            let entry = tool_call_builders.entry(index).or_insert((
-                                None,
-                                None,
-                                String::new(),
-                            ));
-                            if let Some(id) = tc["id"].as_str() {
-                                if !id.is_empty() {
-                                    entry.0 = Some(id.to_string());
-                                }
-                            }
-                            if let Some(func) = tc.get("function").and_then(|v| v.as_object()) {
-                                if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
-                                    if !name.is_empty() {
-                                        entry.1 = Some(name.to_string());
-                                    }
-                                }
-                                if let Some(args) = func.get("arguments").and_then(|v| v.as_str()) {
-                                    entry.2.push_str(args);
-                                }
+                            if tx.send(Ok(LlmStreamEvent::Token(content))).await.is_err() {
+                                return;
                             }
                         }
                     }
-                    if let Some(finish_reason) = event["choices"][0]["finish_reason"].as_str() {
+                    for tool_call in choice.delta.tool_calls {
+                        if let Err(error) =
+                            merge_tool_call_delta(&mut tool_call_builders, tool_call)
+                        {
+                            let _ = tx.send(Err(error)).await;
+                            return;
+                        }
+                    }
+                    if let Some(finish_reason) = choice.finish_reason {
                         if !finish_reason.is_empty() {
-                            let tool_calls = finalize_tool_calls(&mut tool_call_builders);
+                            let tool_calls = match finalize_tool_calls(&mut tool_call_builders) {
+                                Ok(tool_calls) => tool_calls,
+                                Err(error) => {
+                                    let _ = tx.send(Err(error)).await;
+                                    return;
+                                }
+                            };
                             let _ = tx
                                 .send(Ok(LlmStreamEvent::Done {
-                                    finish_reason: finish_reason.to_string(),
+                                    finish_reason,
                                     tool_calls,
                                 }))
                                 .await;
@@ -189,12 +275,10 @@ impl LlmProvider for OpenAiProvider {
                     }
                 }
             }
-            let tool_calls = finalize_tool_calls(&mut tool_call_builders);
             let _ = tx
-                .send(Ok(LlmStreamEvent::Done {
-                    finish_reason: "stop".to_string(),
-                    tool_calls,
-                }))
+                .send(Err(anyhow::anyhow!(
+                    "LLM stream closed without a finish reason"
+                )))
                 .await;
         });
 
@@ -202,17 +286,173 @@ impl LlmProvider for OpenAiProvider {
     }
 }
 
-fn finalize_tool_calls(
-    builders: &mut BTreeMap<usize, (Option<String>, Option<String>, String)>,
-) -> Vec<ToolCall> {
+fn finalize_tool_calls(builders: &mut BTreeMap<usize, ToolCallBuilder>) -> Result<Vec<ToolCall>> {
     std::mem::take(builders)
         .into_iter()
-        .map(
-            |(_, (id, name, args)): (_, (Option<String>, Option<String>, String))| ToolCall {
-                id: id.unwrap_or_default(),
-                name: name.unwrap_or_default(),
-                arguments: serde_json::from_str(&args).unwrap_or(Value::Null),
+        .map(|(index, builder)| {
+            let id = builder
+                .id
+                .ok_or_else(|| anyhow::anyhow!("tool call index {index} is missing an ID"))?;
+            let name = builder
+                .name
+                .ok_or_else(|| anyhow::anyhow!("tool call index {index} is missing a name"))?;
+            let arguments = serde_json::from_str(&builder.arguments).map_err(|error| {
+                anyhow::anyhow!("tool call index {index} has invalid arguments: {error}")
+            })?;
+            Ok(ToolCall {
+                id,
+                name,
+                arguments,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_content_is_ignored() {
+        let chunk: ChatCompletionChunk = serde_json::from_value(json!({
+            "choices": [{
+                "delta": {
+                    "reasoning_content": "hidden",
+                    "content": "visible"
+                },
+                "finish_reason": null
+            }]
+        }))
+        .unwrap();
+
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("visible"));
+    }
+
+    #[test]
+    fn finalizes_fragmented_tool_call() {
+        let chunks: Vec<ChatCompletionChunk> = serde_json::from_value(json!([
+            {
+                "choices": [{
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "id": "call-1",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": "{\"query\":\""
+                            }
+                        }]
+                    },
+                    "finish_reason": null
+                }]
+            },
+            {
+                "choices": [{
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "function": {
+                                "arguments": "rust\"}"
+                            }
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }]
+            }
+        ]))
+        .unwrap();
+        let mut builders = BTreeMap::new();
+        for chunk in chunks {
+            for tool_call in chunk.choices.into_iter().next().unwrap().delta.tool_calls {
+                merge_tool_call_delta(&mut builders, tool_call).unwrap();
+            }
+        }
+
+        let calls = finalize_tool_calls(&mut builders).unwrap();
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call-1");
+        assert_eq!(calls[0].name, "lookup");
+        assert_eq!(calls[0].arguments, json!({"query": "rust"}));
+    }
+
+    #[test]
+    fn rejects_invalid_tool_call_arguments() {
+        let mut builders = BTreeMap::from([(
+            0,
+            ToolCallBuilder {
+                id: Some("call-1".to_string()),
+                name: Some("lookup".to_string()),
+                arguments: "{".to_string(),
+            },
+        )]);
+
+        let error = finalize_tool_calls(&mut builders).unwrap_err();
+
+        assert!(error.to_string().contains("invalid arguments"));
+    }
+
+    #[test]
+    fn rejects_tool_call_without_identity() {
+        let mut builders = BTreeMap::from([(0, ToolCallBuilder::default())]);
+
+        let error = finalize_tool_calls(&mut builders).unwrap_err();
+
+        assert!(error.to_string().contains("missing an ID"));
+    }
+
+    #[test]
+    fn rejects_too_many_streamed_tool_calls() {
+        let mut builders = BTreeMap::new();
+        for index in 0..MAX_TOOL_CALLS_PER_TURN {
+            merge_tool_call_delta(
+                &mut builders,
+                ToolCallDelta {
+                    index,
+                    id: Some(format!("call-{index}")),
+                    function: Some(FunctionDelta {
+                        name: Some("lookup".to_string()),
+                        arguments: Some("{}".to_string()),
+                    }),
+                },
+            )
+            .unwrap();
+        }
+
+        let error = merge_tool_call_delta(
+            &mut builders,
+            ToolCallDelta {
+                index: MAX_TOOL_CALLS_PER_TURN,
+                id: Some("call-over-limit".to_string()),
+                function: Some(FunctionDelta {
+                    name: Some("lookup".to_string()),
+                    arguments: Some("{}".to_string()),
+                }),
             },
         )
-        .collect()
+        .unwrap_err();
+
+        assert!(error.to_string().contains("per-turn limit"));
+        assert_eq!(builders.len(), MAX_TOOL_CALLS_PER_TURN);
+    }
+
+    #[test]
+    fn rejects_oversized_streamed_tool_arguments() {
+        let mut builders = BTreeMap::new();
+        let error = merge_tool_call_delta(
+            &mut builders,
+            ToolCallDelta {
+                index: 0,
+                id: Some("call-1".to_string()),
+                function: Some(FunctionDelta {
+                    name: Some("lookup".to_string()),
+                    arguments: Some("x".repeat(MAX_TOOL_ARGUMENT_BYTES_TOTAL + 1)),
+                }),
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("total byte limit"));
+        assert!(builders.is_empty());
+    }
 }

--- a/src/llm/tool_loop.rs
+++ b/src/llm/tool_loop.rs
@@ -1,10 +1,15 @@
-use crate::llm::provider::{LlmProvider, LlmStreamEvent, ToolCall};
+use crate::llm::provider::{
+    LlmProvider, LlmStreamEvent, ToolCall, MAX_TOOL_ARGUMENT_BYTES_TOTAL, MAX_TOOL_CALLS_PER_TURN,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use serde_json::{json, Value};
 use thiserror::Error;
 use tracing::{debug, info};
+
+const MAX_TOOL_LOOP_TURNS: usize = 16;
+const MAX_TOOL_CALLS_TOTAL: usize = 32;
 
 #[derive(Default)]
 pub struct StreamCallbacks {
@@ -19,15 +24,19 @@ pub trait ToolExecutor: Send + Sync {
 
 #[derive(Error, Debug)]
 pub enum ToolLoopError {
+    #[error("tool loop exceeded {max_turns} model turns")]
+    MaxTurnsExceeded { max_turns: usize },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 
+#[derive(Debug)]
 pub struct ToolLoopResult {
     pub content: String,
     pub finish_reason: String,
 }
 
+#[derive(Debug)]
 struct AccumulatedResult {
     text: String,
     tool_calls: Vec<ToolCall>,
@@ -73,11 +82,60 @@ async fn accumulate_stream(
         }
     }
 
+    if finish_reason.is_empty() {
+        anyhow::bail!("LLM stream ended without a completion event");
+    }
+
     Ok(AccumulatedResult {
         text,
         tool_calls,
         finish_reason,
     })
+}
+
+fn validate_tool_batch(
+    finish_reason: &str,
+    tool_calls: &[ToolCall],
+    executed_tool_calls: usize,
+    argument_bytes_total: usize,
+) -> Result<usize> {
+    if tool_calls.is_empty() {
+        if finish_reason == "tool_calls" {
+            anyhow::bail!("LLM reported tool_calls without any tool call");
+        }
+        return Ok(0);
+    }
+    if finish_reason != "tool_calls" {
+        anyhow::bail!(
+            "refusing tool calls with finish reason '{finish_reason}'; expected 'tool_calls'"
+        );
+    }
+    if tool_calls.len() > MAX_TOOL_CALLS_PER_TURN {
+        anyhow::bail!("tool call count exceeds the per-turn limit of {MAX_TOOL_CALLS_PER_TURN}");
+    }
+
+    let next_tool_call_count = executed_tool_calls
+        .checked_add(tool_calls.len())
+        .ok_or_else(|| anyhow::anyhow!("tool call count overflowed"))?;
+    if next_tool_call_count > MAX_TOOL_CALLS_TOTAL {
+        anyhow::bail!("tool call count exceeds the total limit of {MAX_TOOL_CALLS_TOTAL}");
+    }
+
+    let turn_argument_bytes = tool_calls.iter().try_fold(0usize, |total, call| {
+        total.checked_add(call.arguments.to_string().len())
+    });
+    let turn_argument_bytes = turn_argument_bytes
+        .ok_or_else(|| anyhow::anyhow!("tool argument byte count overflowed"))?;
+    let next_argument_bytes = argument_bytes_total
+        .checked_add(turn_argument_bytes)
+        .ok_or_else(|| anyhow::anyhow!("tool argument byte count overflowed"))?;
+    if next_argument_bytes > MAX_TOOL_ARGUMENT_BYTES_TOTAL {
+        anyhow::bail!(
+            "tool arguments exceed the total byte limit of {MAX_TOOL_ARGUMENT_BYTES_TOTAL}"
+        );
+    }
+
+    Ok(turn_argument_bytes)
 }
 
 pub async fn run_tool_loop(
@@ -87,10 +145,24 @@ pub async fn run_tool_loop(
     executor: &dyn ToolExecutor,
     callbacks: Option<&StreamCallbacks>,
 ) -> Result<ToolLoopResult, ToolLoopError> {
-    loop {
-        debug!("Tool loop turn (messages: {})", messages.len());
+    let mut executed_tool_calls = 0usize;
+    let mut argument_bytes_total = 0usize;
+
+    for turn in 0..MAX_TOOL_LOOP_TURNS {
+        debug!(
+            "Tool loop turn {}/{} (messages: {})",
+            turn + 1,
+            MAX_TOOL_LOOP_TURNS,
+            messages.len()
+        );
 
         let acc = accumulate_stream(messages, tools, provider, callbacks).await?;
+        let turn_argument_bytes = validate_tool_batch(
+            &acc.finish_reason,
+            &acc.tool_calls,
+            executed_tool_calls,
+            argument_bytes_total,
+        )?;
 
         if acc.tool_calls.is_empty() {
             let result = ToolLoopResult {
@@ -104,6 +176,15 @@ pub async fn run_tool_loop(
             );
             return Ok(result);
         }
+
+        if turn + 1 == MAX_TOOL_LOOP_TURNS {
+            return Err(ToolLoopError::MaxTurnsExceeded {
+                max_turns: MAX_TOOL_LOOP_TURNS,
+            });
+        }
+
+        executed_tool_calls += acc.tool_calls.len();
+        argument_bytes_total += turn_argument_bytes;
 
         let assistant_tool_calls: Vec<Value> = acc
             .tool_calls
@@ -149,5 +230,209 @@ pub async fn run_tool_loop(
                 "content": result,
             }));
         }
+    }
+
+    unreachable!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream::{self, BoxStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct RepeatingProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for RepeatingProvider {
+        async fn chat_completion_stream(
+            &self,
+            _messages: Vec<Value>,
+            _tools: Vec<Value>,
+        ) -> Result<BoxStream<'static, Result<LlmStreamEvent>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::pin(stream::iter([Ok(LlmStreamEvent::Done {
+                finish_reason: "tool_calls".to_string(),
+                tool_calls: vec![ToolCall {
+                    id: "call-1".to_string(),
+                    name: "lookup".to_string(),
+                    arguments: json!({}),
+                }],
+            })])))
+        }
+    }
+
+    struct CountingExecutor {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for CountingExecutor {
+        async fn execute(&self, _call: &ToolCall) -> String {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            "ok".to_string()
+        }
+    }
+
+    #[tokio::test]
+    async fn stops_before_executing_unbounded_tool_calls() {
+        let provider = RepeatingProvider {
+            calls: AtomicUsize::new(0),
+        };
+        let executor = CountingExecutor {
+            calls: AtomicUsize::new(0),
+        };
+        let mut messages = Vec::new();
+
+        let error = run_tool_loop(&mut messages, &[], &provider, &executor, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ToolLoopError::MaxTurnsExceeded { .. }));
+        assert_eq!(provider.calls.load(Ordering::SeqCst), MAX_TOOL_LOOP_TURNS);
+        assert_eq!(
+            executor.calls.load(Ordering::SeqCst),
+            MAX_TOOL_LOOP_TURNS - 1
+        );
+    }
+
+    struct EmptyProvider;
+
+    #[async_trait]
+    impl LlmProvider for EmptyProvider {
+        async fn chat_completion_stream(
+            &self,
+            _messages: Vec<Value>,
+            _tools: Vec<Value>,
+        ) -> Result<BoxStream<'static, Result<LlmStreamEvent>>> {
+            Ok(Box::pin(stream::empty()))
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_stream_without_completion_event() {
+        let error = accumulate_stream(&[], &[], &EmptyProvider, None)
+            .await
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("ended without a completion event"));
+    }
+
+    struct FixedProvider {
+        calls: AtomicUsize,
+        finish_reason: &'static str,
+        tool_calls: Vec<ToolCall>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FixedProvider {
+        async fn chat_completion_stream(
+            &self,
+            _messages: Vec<Value>,
+            _tools: Vec<Value>,
+        ) -> Result<BoxStream<'static, Result<LlmStreamEvent>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::pin(stream::iter([Ok(LlmStreamEvent::Done {
+                finish_reason: self.finish_reason.to_string(),
+                tool_calls: self.tool_calls.clone(),
+            })])))
+        }
+    }
+
+    fn tool_calls(count: usize, arguments: Value) -> Vec<ToolCall> {
+        (0..count)
+            .map(|index| ToolCall {
+                id: format!("call-{index}"),
+                name: "lookup".to_string(),
+                arguments: arguments.clone(),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn rejects_tool_calls_with_non_tool_finish_reason() {
+        let provider = FixedProvider {
+            calls: AtomicUsize::new(0),
+            finish_reason: "length",
+            tool_calls: tool_calls(1, json!({})),
+        };
+        let executor = CountingExecutor {
+            calls: AtomicUsize::new(0),
+        };
+        let mut messages = Vec::new();
+
+        let error = run_tool_loop(&mut messages, &[], &provider, &executor, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("expected 'tool_calls'"));
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn rejects_too_many_tool_calls_in_one_turn() {
+        let provider = FixedProvider {
+            calls: AtomicUsize::new(0),
+            finish_reason: "tool_calls",
+            tool_calls: tool_calls(MAX_TOOL_CALLS_PER_TURN + 1, json!({})),
+        };
+        let executor = CountingExecutor {
+            calls: AtomicUsize::new(0),
+        };
+        let mut messages = Vec::new();
+
+        let error = run_tool_loop(&mut messages, &[], &provider, &executor, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("per-turn limit"));
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn rejects_tool_calls_over_total_limit() {
+        let provider = FixedProvider {
+            calls: AtomicUsize::new(0),
+            finish_reason: "tool_calls",
+            tool_calls: tool_calls(MAX_TOOL_CALLS_PER_TURN, json!({})),
+        };
+        let executor = CountingExecutor {
+            calls: AtomicUsize::new(0),
+        };
+        let mut messages = Vec::new();
+
+        let error = run_tool_loop(&mut messages, &[], &provider, &executor, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("total limit"));
+        assert_eq!(executor.calls.load(Ordering::SeqCst), MAX_TOOL_CALLS_TOTAL);
+    }
+
+    #[tokio::test]
+    async fn rejects_tool_arguments_over_cumulative_byte_limit() {
+        let provider = FixedProvider {
+            calls: AtomicUsize::new(0),
+            finish_reason: "tool_calls",
+            tool_calls: tool_calls(
+                1,
+                Value::String("x".repeat(MAX_TOOL_ARGUMENT_BYTES_TOTAL / 2)),
+            ),
+        };
+        let executor = CountingExecutor {
+            calls: AtomicUsize::new(0),
+        };
+        let mut messages = Vec::new();
+
+        let error = run_tool_loop(&mut messages, &[], &provider, &executor, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("total byte limit"));
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/permission/gate.rs
+++ b/src/permission/gate.rs
@@ -65,12 +65,76 @@ impl PermissionGate {
             return true;
         }
 
-        for rule in &self.config.rules {
-            if self.matches_rule(rule, caller_groups, caller_channel_group_id) {
-                return rule.can_target_admins;
-            }
-        }
+        self.config.rules.iter().any(|rule| {
+            rule.can_target_admins
+                && self.matches_rule(rule, caller_groups, caller_channel_group_id)
+        })
+    }
+}
 
-        false
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::acl::AclSettings;
+
+    fn rule(name: &str, server_group_ids: Vec<u32>, can_target_admins: bool) -> AclRule {
+        AclRule {
+            name: name.to_string(),
+            server_group_ids,
+            channel_group_ids: Vec::new(),
+            allowed_skills: Vec::new(),
+            can_target_admins,
+        }
+    }
+
+    #[test]
+    fn target_permission_combines_all_matching_rules() {
+        let gate = PermissionGate::new(AclConfig {
+            rules: vec![
+                rule("default", Vec::new(), false),
+                rule("admin", vec![6], true),
+            ],
+            acl: AclSettings {
+                protected_group_ids: vec![6],
+            },
+        });
+
+        assert!(gate.can_target(&[6], 0, &[6]));
+    }
+
+    #[test]
+    fn protected_target_is_denied_without_an_explicit_grant() {
+        let gate = PermissionGate::new(AclConfig {
+            rules: vec![rule("default", Vec::new(), false)],
+            acl: AclSettings {
+                protected_group_ids: vec![6],
+            },
+        });
+
+        assert!(!gate.can_target(&[8], 0, &[6]));
+    }
+
+    #[test]
+    fn nonzero_channel_group_controls_skills_and_protected_targets() {
+        let gate = PermissionGate::new(AclConfig {
+            rules: vec![AclRule {
+                name: "channel-admin".to_string(),
+                server_group_ids: Vec::new(),
+                channel_group_ids: vec![42],
+                allowed_skills: vec!["move_client".to_string()],
+                can_target_admins: true,
+            }],
+            acl: AclSettings {
+                protected_group_ids: vec![6],
+            },
+        });
+
+        assert_eq!(
+            gate.get_allowed_skills(&[], 42),
+            vec!["move_client".to_string()]
+        );
+        assert!(gate.get_allowed_skills(&[], 0).is_empty());
+        assert!(gate.can_target(&[], 42, &[6]));
+        assert!(!gate.can_target(&[], 0, &[6]));
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,16 +62,13 @@ pub async fn run_routers(
             registry,
             Some(adapter),
         );
-        let nc_future = tokio::spawn(async move { nc_router.run().await });
 
         info!("{bot_ctx}");
 
         tokio::select! {
             res = ts_router.run() => map_ts_router_result(res),
-            res = nc_future => map_nc_router_result(res),
-            _ = tokio::signal::ctrl_c() => {
-                Ok(())
-            }
+            res = nc_router.run() => map_nc_router_result(res),
+            res = tokio::signal::ctrl_c() => res.map_err(Into::into),
             _ = sigterm => {
                 Ok(())
             }
@@ -102,9 +99,7 @@ pub async fn run_routers(
 
         tokio::select! {
             res = ts_router.run() => map_ts_router_result(res),
-            _ = tokio::signal::ctrl_c() => {
-                Ok(())
-            }
+            res = tokio::signal::ctrl_c() => res.map_err(Into::into),
             _ = sigterm => {
                 Ok(())
             }
@@ -125,19 +120,15 @@ fn map_ts_router_result(res: Result<()>) -> Result<()> {
     }
 }
 
-fn map_nc_router_result(res: Result<Result<()>, tokio::task::JoinError>) -> Result<()> {
+fn map_nc_router_result(res: Result<()>) -> Result<()> {
     match res {
-        Ok(Ok(())) => {
+        Ok(()) => {
             warn!("NC router exited unexpectedly");
             Err(anyhow::anyhow!("NC router exited unexpectedly"))
         }
-        Ok(Err(e)) => {
+        Err(e) => {
             error!("NC router error: {e}");
             Err(e)
-        }
-        Err(e) => {
-            error!("NC router task panicked: {e}");
-            Err(anyhow::anyhow!("NC router panicked"))
         }
     }
 }

--- a/src/router/nc_router.rs
+++ b/src/router/nc_router.rs
@@ -6,12 +6,12 @@ use crate::adapter::napcat::{
     NapCatAdapter,
 };
 use crate::adapter::TsAdapter;
-use crate::config::{AppConfig, PromptsConfig};
+use crate::config::{AppConfig, NapCatConfig, PromptsConfig};
 use crate::llm::context::SessionSource;
 use crate::llm::{LlmEngine, ToolCall, ToolExecutor};
 use crate::permission::PermissionGate;
 use crate::router::{ReplyPolicy, UnifiedInboundEvent};
-use crate::skills::{NcExecutionContext, SkillRegistry, UnifiedExecutionContext};
+use crate::skills::{is_skill_allowed, NcExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use anyhow::Result;
 use serde_json::json;
 use std::sync::Arc;
@@ -22,13 +22,22 @@ struct NcExecutor<'a> {
     user_id: i64,
     group_id: Option<i64>,
     sender_name: &'a str,
+    caller_groups: &'a [u32],
+    allowed_skills: &'a [String],
 }
 
 #[async_trait]
 impl ToolExecutor for NcExecutor<'_> {
     async fn execute(&self, call: &ToolCall) -> String {
         self.router
-            .execute_skill(call, self.user_id, self.group_id, self.sender_name)
+            .execute_skill(
+                call,
+                self.user_id,
+                self.group_id,
+                self.sender_name,
+                self.caller_groups,
+                self.allowed_skills,
+            )
             .await
     }
 }
@@ -43,24 +52,21 @@ pub struct NcRouter {
     ts_adapter: Option<Arc<TsAdapter>>,
 }
 
-impl NcRouter {
-    fn resolve_nc_allowed_skills(&self, user_id: i64, group_id: Option<i64>) -> Vec<String> {
-        let mut pseudo_groups = vec![9000u32];
-        if group_id.is_some() {
-            pseudo_groups.push(9001);
-        }
-        if self.config.napcat.trusted_users.contains(&user_id) {
-            pseudo_groups.push(9002);
-        }
-        if group_id
-            .map(|gid| self.config.napcat.trusted_groups.contains(&gid))
-            .unwrap_or(false)
-        {
-            pseudo_groups.push(9003);
-        }
-        self.gate.get_allowed_skills(&pseudo_groups, 0)
+fn nc_pseudo_groups(config: &NapCatConfig, user_id: i64, group_id: Option<i64>) -> Vec<u32> {
+    let mut groups = vec![9000];
+    if group_id.is_some() {
+        groups.push(9001);
     }
+    if config.trusted_users.contains(&user_id) {
+        groups.push(9002);
+    }
+    if group_id.is_some_and(|gid| config.trusted_groups.contains(&gid)) {
+        groups.push(9003);
+    }
+    groups
+}
 
+impl NcRouter {
     fn is_trusted(&self, user_id: i64, group_id: Option<i64>) -> bool {
         let nc = &self.config.napcat;
         if nc.trusted_users.contains(&user_id) {
@@ -98,7 +104,20 @@ impl NcRouter {
         let mut rx = self.adapter.subscribe();
         info!("NcRouter: listening for NapCat events");
 
-        while let Ok(event) = rx.recv().await {
+        loop {
+            let event = match rx.recv().await {
+                Ok(event) => event,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "NapCat event router lagged; skipped buffered events"
+                    );
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err(anyhow::anyhow!("NcRouter event stream closed"));
+                }
+            };
             match event {
                 NcEvent::PrivateMessage(msg) => {
                     if msg.user_id == self.adapter.get_self_id() {
@@ -132,7 +151,6 @@ impl NcRouter {
                 }
             }
         }
-        Err(anyhow::anyhow!("NcRouter event stream ended"))
     }
 
     fn spawn_handle_private(&self, msg: PrivateMessageEvent) {
@@ -200,13 +218,23 @@ impl NcRouter {
 
         let stripped = self.strip_prefix(&unified_event.text);
 
-        info!("[NC Private] user={} msg={}", msg.sender.nickname, stripped);
+        info!(
+            user_id = msg.user_id,
+            user = %msg.sender.nickname,
+            message_chars = stripped.chars().count(),
+            "[NC Private] message received"
+        );
 
-        let allowed = self.resolve_nc_allowed_skills(msg.user_id, None);
-        debug!("NC private allowed skills: {:?}", allowed);
+        let caller_groups = nc_pseudo_groups(&self.config.napcat, msg.user_id, None);
 
         let reply_text = self
-            .run_llm(stripped, &msg.sender.nickname, msg.user_id, None, &allowed)
+            .run_llm(
+                stripped,
+                &msg.sender.nickname,
+                msg.user_id,
+                None,
+                &caller_groups,
+            )
             .await;
 
         if let ReplyPolicy::NapCatPrivate { user_id } = unified_event.reply_policy {
@@ -218,7 +246,7 @@ impl NcRouter {
     }
 
     async fn handle_group(&self, msg: GroupMessageEvent) {
-        let triggered = self.is_triggered(segments_to_text(&msg.message).trim());
+        let triggered = self.is_triggered(&msg.message);
         let Some(unified_event) = UnifiedInboundEvent::from_nc_group(&msg, triggered) else {
             return;
         };
@@ -238,12 +266,14 @@ impl NcRouter {
         let stripped = self.strip_prefix(&unified_event.text);
 
         info!(
-            "[NC Group {}] user={} msg={}",
-            msg.group_id, msg.sender.nickname, stripped
+            group_id = msg.group_id,
+            user_id = msg.user_id,
+            user = %msg.sender.nickname,
+            message_chars = stripped.chars().count(),
+            "[NC Group] message received"
         );
 
-        let allowed = self.resolve_nc_allowed_skills(msg.user_id, Some(msg.group_id));
-        debug!("NC group allowed skills: {:?}", allowed);
+        let caller_groups = nc_pseudo_groups(&self.config.napcat, msg.user_id, Some(msg.group_id));
 
         let reply_text = self
             .run_llm(
@@ -251,7 +281,7 @@ impl NcRouter {
                 &msg.sender.nickname,
                 msg.user_id,
                 Some(msg.group_id),
-                &allowed,
+                &caller_groups,
             )
             .await;
 
@@ -272,9 +302,17 @@ impl NcRouter {
         }
     }
 
-    fn is_triggered(&self, text: &str) -> bool {
+    fn is_triggered(&self, message: &[Segment]) -> bool {
         let nc = &self.config.napcat;
         let self_id = self.adapter.get_self_id().to_string();
+        if message
+            .iter()
+            .any(|segment| matches!(segment, Segment::At { qq } if qq == &self_id))
+        {
+            return true;
+        }
+        let text = segments_to_text(message);
+        let text = text.trim();
         if text.contains(&format!("[CQ:at,qq={self_id}]")) {
             return true;
         }
@@ -300,12 +338,20 @@ impl NcRouter {
         user_id: i64,
         group_id: Option<i64>,
         sender_name: &str,
+        caller_groups: &[u32],
+        allowed_skills: &[String],
     ) -> String {
+        if !is_skill_allowed(&call.name, allowed_skills) {
+            warn!(skill = %call.name, "NC Skill execution denied by ACL");
+            return "Skill execution denied".to_string();
+        }
+
         if let Some(skill) = self.registry.get(&call.name) {
             let nc_ctx = NcExecutionContext {
                 adapter: self.adapter.clone(),
                 caller_id: user_id,
                 caller_name: sender_name.to_string(),
+                caller_groups: caller_groups.to_vec(),
                 caller_group_id: group_id,
                 gate: self.gate.clone(),
                 config: self.config.clone(),
@@ -313,43 +359,22 @@ impl NcRouter {
             let unified_ctx = UnifiedExecutionContext::from_nc(&nc_ctx)
                 .with_cross_adapters(self.ts_adapter.clone(), Some(self.adapter.clone()));
 
-            let args = call.arguments.clone();
-            match skill.execute_unified(args.clone(), &unified_ctx).await {
+            match skill
+                .execute_unified(call.arguments.clone(), &unified_ctx)
+                .await
+            {
                 Ok(val) => {
                     info!(
                         skill = %call.name,
                         caller = %sender_name,
-                        result = %val,
                         "NC Unified Skill executed"
                     );
                     val.to_string()
                 }
-                Err(unified_err) => {
-                    debug!(skill = %call.name, error = %unified_err, "Falling back to NC execution");
-                    let nc_ctx = NcExecutionContext {
-                        adapter: self.adapter.clone(),
-                        caller_id: user_id,
-                        caller_name: sender_name.to_string(),
-                        caller_group_id: group_id,
-                        gate: self.gate.clone(),
-                        config: self.config.clone(),
-                    };
-                    match skill.execute_nc(call.arguments.clone(), &nc_ctx).await {
-                        Ok(val) => {
-                            info!(
-                                skill = %call.name,
-                                caller = %sender_name,
-                                result = %val,
-                                "NC Skill executed"
-                            );
-                            val.to_string()
-                        }
-                        Err(e) => {
-                            let msg = format!("Skill execution failed: {}", e);
-                            error!(skill = %call.name, error = %e, "NC Skill failed");
-                            msg
-                        }
-                    }
+                Err(e) => {
+                    let msg = format!("Skill execution failed: {}", e);
+                    error!(skill = %call.name, error = %e, "NC Skill failed");
+                    msg
                 }
             }
         } else {
@@ -365,7 +390,7 @@ impl NcRouter {
         sender_name: &str,
         user_id: i64,
         group_id: Option<i64>,
-        allowed_skills: &[String],
+        caller_groups: &[u32],
     ) -> String {
         let error_msg = "AI backend unavailable. Please try again later.".to_string();
 
@@ -412,13 +437,17 @@ impl NcRouter {
             .llm
             .build_messages(&source, system_prompt, &user_ctx, user_msg);
 
-        let tools = self.registry.to_tool_schemas(allowed_skills);
+        let allowed_skills = self.gate.get_allowed_skills(caller_groups, 0);
+        debug!("NC allowed skills: {:?}", allowed_skills);
+        let tools = self.registry.to_tool_schemas(&allowed_skills);
 
         let executor = NcExecutor {
             router: self,
             user_id,
             group_id,
             sender_name,
+            caller_groups,
+            allowed_skills: &allowed_skills,
         };
 
         match self
@@ -428,7 +457,10 @@ impl NcRouter {
         {
             Ok(result) => {
                 let content = result.content;
-                info!("[NC] LLM final reply: {}", content);
+                info!(
+                    reply_chars = content.chars().count(),
+                    "[NC] LLM final reply ready"
+                );
                 self.llm
                     .save_turn(&source, user_msg.to_string(), content.clone());
                 content
@@ -438,5 +470,34 @@ impl NcRouter {
                 error_msg
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_chat_uses_base_and_trusted_user_groups() {
+        let config = NapCatConfig {
+            trusted_users: vec![42],
+            ..NapCatConfig::default()
+        };
+
+        assert_eq!(nc_pseudo_groups(&config, 42, None), vec![9000, 9002]);
+    }
+
+    #[test]
+    fn group_chat_uses_all_matching_pseudo_groups() {
+        let config = NapCatConfig {
+            trusted_users: vec![42],
+            trusted_groups: vec![7],
+            ..NapCatConfig::default()
+        };
+
+        assert_eq!(
+            nc_pseudo_groups(&config, 42, Some(7)),
+            vec![9000, 9001, 9002, 9003]
+        );
     }
 }

--- a/src/router/ts_router.rs
+++ b/src/router/ts_router.rs
@@ -17,13 +17,20 @@ struct SqExecutor<'a> {
     event: &'a TextMessageEvent,
     groups: &'a [u32],
     channel_group_id: u32,
+    allowed_skills: &'a [String],
 }
 
 #[async_trait]
 impl ToolExecutor for SqExecutor<'_> {
     async fn execute(&self, call: &ToolCall) -> String {
         self.router
-            .execute_skill(call, self.event, self.groups, self.channel_group_id)
+            .execute_skill(
+                call,
+                self.event,
+                self.groups,
+                self.channel_group_id,
+                self.allowed_skills,
+            )
             .await
     }
 }
@@ -63,13 +70,22 @@ impl EventRouter {
     pub async fn run(&self) -> Result<()> {
         let mut rx = self.adapter.subscribe();
 
-        while let Ok(TsEvent::TextMessage(msg)) = rx.recv().await {
-            let this = self.clone();
-            tokio::spawn(async move {
-                this.handle_message(msg).await;
-            });
+        loop {
+            match rx.recv().await {
+                Ok(TsEvent::TextMessage(msg)) => {
+                    let this = self.clone();
+                    tokio::spawn(async move {
+                        this.handle_message(msg).await;
+                    });
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(skipped, "TS event router lagged; skipped buffered events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err(anyhow::anyhow!("TS event stream closed"));
+                }
+            }
         }
-        Ok(())
     }
 
     async fn execute_skill(
@@ -78,6 +94,7 @@ impl EventRouter {
         event: &TextMessageEvent,
         groups: &[u32],
         channel_group_id: u32,
+        allowed_skills: &[String],
     ) -> String {
         let ctx = ExecutionContext {
             adapter: self.adapter.clone(),
@@ -89,7 +106,7 @@ impl EventRouter {
             config: self.config.clone(),
         };
         self.registry
-            .execute_skill(call, ctx, self.nc_adapter.clone())
+            .execute_skill(call, ctx, allowed_skills, self.nc_adapter.clone())
             .await
     }
 
@@ -112,7 +129,10 @@ impl EventRouter {
         }
 
         // 开启了语音桥接时，纯文本由 voice_router 处理
-        if self.config.headless.stt.enabled || self.config.headless.tts.enabled {
+        if self.config.headless.stt.enabled
+            || self.config.headless.tts.enabled
+            || self.config.llm.omni_model
+        {
             return;
         }
 
@@ -133,8 +153,10 @@ impl EventRouter {
 
         let msg_content = unified_event.text.as_str();
         info!(
-            "Message received: {} (clid: {}, content: {})",
-            event.invoker_name, event.invoker_id, msg_content
+            invoker = %event.invoker_name,
+            clid = event.invoker_id,
+            message_chars = msg_content.chars().count(),
+            "Message received"
         );
 
         let groups: Vec<u32> = event
@@ -142,10 +164,24 @@ impl EventRouter {
             .iter()
             .filter_map(|g| g.parse().ok())
             .collect();
-        let channel_group_id = 0;
+        let channel_group_id = match self
+            .adapter
+            .get_client_channel_group_id(event.invoker_id)
+            .await
+        {
+            Ok(channel_group_id) => channel_group_id,
+            Err(error) => {
+                error!(
+                    clid = event.invoker_id,
+                    error = %error,
+                    "Failed to resolve caller channel group"
+                );
+                return;
+            }
+        };
 
         let source = SessionSource::TeamSpeak {
-            clid: event.invoker_id,
+            uid: event.invoker_uid.clone(),
         };
         let system_prompt = &self.prompts.system.content;
 
@@ -189,6 +225,7 @@ Online: {}"#,
             event: &event,
             groups: &groups,
             channel_group_id,
+            allowed_skills: &allowed_skills,
         };
 
         // 注意这里传入了 None 作为 callbacks，意味着等待流式全部完成后拿整体回复
@@ -199,7 +236,10 @@ Online: {}"#,
         {
             Ok(result) => {
                 if !result.content.is_empty() {
-                    info!("[TS] LLM final reply: {}", &result.content);
+                    info!(
+                        reply_chars = result.content.chars().count(),
+                        "[TS] LLM final reply ready"
+                    );
                     self.llm
                         .save_turn(&source, msg_content.to_string(), result.content.clone());
                     let _ = self

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -3,16 +3,18 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use futures_util::StreamExt;
 use serde_json::json;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinSet;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
 use tracing::{debug, error, info, warn};
 
 use crate::adapter::headless::speech::{
     detect_audio_format, is_speakable, pcm16_mono_to_wav_bytes, preprocess_stt_text,
-    preprocess_text_message, OpenAiSpeechProvider, OpusSttPipeline,
+    preprocess_text_message, OpenAiSpeechProvider, OpusSttPipeline, SpeechChunk,
 };
 use crate::adapter::headless::tsbot::voice::v1 as voicev1;
 use crate::adapter::headless::INTERNAL_GRPC_ADDR;
@@ -23,8 +25,11 @@ use crate::permission::PermissionGate;
 use crate::skills::{ExecutionContext, SkillRegistry};
 use voicev1::voice_service_client::VoiceServiceClient;
 
+const AUDIO_MAX_IN_FLIGHT: usize = 8;
+
 struct CallerContext {
     caller_id: u32,
+    caller_uid: String,
     caller_name: String,
     groups: Vec<u32>,
     channel_group_id: u32,
@@ -33,15 +38,64 @@ struct CallerContext {
     reply_target_client_id: u32,
 }
 
+enum ManagedTaskExit {
+    Handler,
+    AudioHandler,
+}
+
+#[derive(Default)]
+struct SessionLocks {
+    locks: StdMutex<HashMap<String, Weak<Mutex<()>>>>,
+}
+
+impl SessionLocks {
+    fn for_uid(&self, uid: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.locks.lock().expect("session lock map poisoned");
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(uid).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(uid.to_string(), Arc::downgrade(&lock));
+        lock
+    }
+}
+
+async fn abort_managed_tasks(tasks: &mut JoinSet<ManagedTaskExit>) {
+    tasks.abort_all();
+    while let Some(result) = tasks.join_next().await {
+        if let Err(error) = result {
+            if !error.is_cancelled() {
+                error!("Voice router task failed during shutdown: {error}");
+            }
+        }
+    }
+}
+
+async fn acquire_audio_slot(limit: Arc<Semaphore>) -> Result<OwnedSemaphorePermit> {
+    limit
+        .acquire_owned()
+        .await
+        .map_err(|error| anyhow::anyhow!("voice audio request limit closed: {error}"))
+}
+
+fn should_close_tts_turn(finish_reason: &str) -> bool {
+    finish_reason != "tool_calls"
+}
+
 struct SkillExecutor<'a> {
     router: &'a VoiceRouter,
     ctx: &'a CallerContext,
+    allowed_skills: &'a [String],
 }
 
 #[async_trait]
 impl ToolExecutor for SkillExecutor<'_> {
     async fn execute(&self, call: &ToolCall) -> String {
-        self.router.execute_skill(call, self.ctx).await
+        self.router
+            .execute_skill(call, self.ctx, self.allowed_skills)
+            .await
     }
 }
 
@@ -53,11 +107,11 @@ pub struct VoiceRouter {
     registry: Arc<SkillRegistry>,
     ts_adapter: Arc<TsAdapter>,
     audio_pipeline: Mutex<Option<OpusSttPipeline>>,
+    session_locks: SessionLocks,
     speech_provider: Option<Arc<OpenAiSpeechProvider>>,
 }
 
 impl VoiceRouter {
-    const OBS_TEXT_MAX_LEN: usize = 240;
     const STREAM_TTS_MIN_CHARS: usize = 4;
     const STREAM_TTS_WEAK_PUNCT_MIN_CHARS: usize = 8;
     const STREAM_TTS_MAX_CHARS: usize = 28;
@@ -77,6 +131,7 @@ impl VoiceRouter {
         let need_audio_pipeline = config.headless.stt.enabled || config.llm.omni_model;
         Self {
             audio_pipeline: Mutex::new(need_audio_pipeline.then(OpusSttPipeline::new)),
+            session_locks: SessionLocks::default(),
             config,
             prompts,
             gate,
@@ -102,88 +157,141 @@ impl VoiceRouter {
             include_audio: self.config.headless.stt.enabled || self.config.llm.omni_model,
         });
         let mut stream = client.subscribe_events(req).await?.into_inner();
+        let router = Arc::new(self);
+        let audio_limit = Arc::new(Semaphore::new(AUDIO_MAX_IN_FLIGHT));
+        let mut tasks = JoinSet::new();
 
-        while let Some(item) = stream.next().await {
-            match item {
-                Ok(ev) => {
+        let result = loop {
+            tokio::select! {
+                item = stream.next() => {
+                    let Some(item) = item else {
+                        break Err(anyhow::anyhow!("voice event stream ended"));
+                    };
+                    let ev = match item {
+                        Ok(ev) => ev,
+                        Err(error) => {
+                            break Err(anyhow::anyhow!("voice event stream error: {error}"));
+                        }
+                    };
                     let Some(payload) = ev.payload else {
                         continue;
                     };
                     match payload {
                         voicev1::event::Payload::Chat(chat) => {
-                            if let Err(e) = self.handle_chat_event(&mut client, chat).await {
-                                error!("Voice router chat handling failed: {e}");
-                            }
+                            let router = router.clone();
+                            let mut client = client.clone();
+                            tasks.spawn(async move {
+                                if let Err(error) = router.handle_chat_event(&mut client, chat).await {
+                                    error!("Voice router chat handling failed: {error}");
+                                }
+                                ManagedTaskExit::Handler
+                            });
                         }
                         voicev1::event::Payload::Audio(audio) => {
-                            if let Err(e) = self.handle_audio_event(&mut client, audio).await {
-                                error!("Voice router audio handling failed: {e}");
+                            match router.process_audio_frame(&audio).await {
+                                Ok(Some(chunk)) => {
+                                    let permit = match acquire_audio_slot(audio_limit.clone()).await {
+                                        Ok(permit) => permit,
+                                        Err(error) => {
+                                            break Err(error);
+                                        }
+                                    };
+                                    let router = router.clone();
+                                    let mut client = client.clone();
+                                    tasks.spawn(async move {
+                                        let _permit = permit;
+                                        if let Err(error) = router
+                                            .handle_audio_chunk(&mut client, audio, chunk)
+                                            .await
+                                        {
+                                            error!("Voice router audio handling failed: {error}");
+                                        }
+                                        ManagedTaskExit::AudioHandler
+                                    });
+                                }
+                                Ok(None) => {}
+                                Err(error) => {
+                                    error!("Voice router audio decoding failed: {error}");
+                                }
                             }
                         }
                         _ => {}
                     }
                 }
-                Err(e) => {
-                    warn!("voice event stream error: {e}");
-                    break;
+                task = tasks.join_next(), if !tasks.is_empty() => {
+                    match task {
+                        Some(Ok(ManagedTaskExit::Handler))
+                        | Some(Ok(ManagedTaskExit::AudioHandler)) => {}
+                        Some(Err(error)) => {
+                            break Err(anyhow::anyhow!("voice router task failed: {error}"));
+                        }
+                        None => {
+                            break Err(anyhow::anyhow!("voice router task set closed"));
+                        }
+                    }
                 }
             }
-        }
-        Ok(())
+        };
+
+        abort_managed_tasks(&mut tasks).await;
+        result
     }
 
-    fn truncate_for_log(&self, text: &str) -> String {
-        let max_len = Self::OBS_TEXT_MAX_LEN.max(16);
-        if text.len() <= max_len {
-            return text.to_string();
-        }
-        let mut s = text.chars().take(max_len).collect::<String>();
-        s.push_str("...");
-        s
-    }
-
-    async fn resolve_caller_from_chat(&self, chat: &voicev1::ChatEvent) -> CallerContext {
-        match self.ts_adapter.list_clients().await {
-            Ok(clients) => {
-                if let Some(c) = clients.iter().find(|c| c.nickname == chat.invoker_name) {
-                    let groups: Vec<u32> = c
-                        .server_groups
-                        .iter()
-                        .filter_map(|g| g.parse().ok())
-                        .collect();
-                    debug!(
-                        "Resolved chat caller '{}' from online list: clid={}",
-                        chat.invoker_name, c.id
-                    );
-                    return CallerContext {
-                        caller_id: c.id as u32,
-                        caller_name: chat.invoker_name.clone(),
-                        groups,
-                        channel_group_id: 0,
-                        channel_id: c.channel_id,
-                        reply_target_mode: chat.reply_target_mode,
-                        reply_target_client_id: chat.reply_target_client_id,
-                    };
-                }
-                debug!(
-                    "Chat caller '{}' not found in online list, using fallback",
-                    chat.invoker_name
-                );
-            }
-            Err(e) => warn!("Failed to list clients for chat caller resolution: {e}"),
-        }
-        CallerContext {
-            caller_id: 0,
+    async fn resolve_caller_from_chat(&self, chat: &voicev1::ChatEvent) -> Result<CallerContext> {
+        let caller_uid = if chat.invoker_unique_id.is_empty() {
+            format!("clid:{}", chat.invoker_client_id)
+        } else {
+            chat.invoker_unique_id.clone()
+        };
+        let clients = self
+            .ts_adapter
+            .list_clients()
+            .await
+            .map_err(|error| anyhow::anyhow!("list chat caller failed: {error}"))?;
+        let caller = clients
+            .iter()
+            .find(|client| u32::try_from(client.id).ok() == Some(chat.invoker_client_id))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "chat caller {} not found in online clients",
+                    chat.invoker_client_id
+                )
+            })?;
+        let channel_group_id = self
+            .ts_adapter
+            .get_client_channel_group_id(chat.invoker_client_id)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "resolve chat caller {} channel group failed: {error}",
+                    chat.invoker_client_id
+                )
+            })?;
+        let groups: Vec<u32> = caller
+            .server_groups
+            .iter()
+            .filter_map(|group| group.parse().ok())
+            .collect();
+        debug!(
+            "Resolved chat caller '{}' from online list: clid={}",
+            chat.invoker_name, caller.id
+        );
+        Ok(CallerContext {
+            caller_id: chat.invoker_client_id,
+            caller_uid,
             caller_name: chat.invoker_name.clone(),
-            groups: vec![],
-            channel_group_id: 0,
-            channel_id: 0,
+            groups,
+            channel_group_id,
+            channel_id: caller.channel_id,
             reply_target_mode: chat.reply_target_mode,
             reply_target_client_id: chat.reply_target_client_id,
-        }
+        })
     }
 
-    async fn resolve_caller_from_audio(&self, audio: &voicev1::AudioFrameEvent) -> CallerContext {
+    async fn resolve_caller_from_audio(
+        &self,
+        audio: &voicev1::AudioFrameEvent,
+    ) -> Result<CallerContext> {
         let reply_target_mode = match self.config.bot.default_reply_mode.as_str() {
             "channel" => 2,
             "server" => 3,
@@ -194,55 +302,96 @@ impl VoiceRouter {
         } else {
             0
         };
-        match self.ts_adapter.list_clients().await {
-            Ok(clients) => {
-                if let Some(c) = clients.iter().find(|c| c.id as u32 == audio.from_client_id) {
-                    let groups: Vec<u32> = c
-                        .server_groups
-                        .iter()
-                        .filter_map(|g| g.parse().ok())
-                        .collect();
-                    debug!(
-                        "Resolved audio caller '{}' from online list: clid={}",
-                        audio.from_client_name, c.id
-                    );
-                    return CallerContext {
-                        caller_id: c.id as u32,
-                        caller_name: c.nickname.clone(),
-                        groups,
-                        channel_group_id: 0,
-                        channel_id: c.channel_id,
-                        reply_target_mode,
-                        reply_target_client_id,
-                    };
-                }
-                debug!(
-                    "Audio caller '{}' not found in online list, using fallback",
-                    audio.from_client_name
-                );
-            }
-            Err(e) => warn!("Failed to list clients for audio caller resolution: {e}"),
-        }
-        CallerContext {
+        let clients = self
+            .ts_adapter
+            .list_clients()
+            .await
+            .map_err(|error| anyhow::anyhow!("list audio caller failed: {error}"))?;
+        let caller = clients
+            .iter()
+            .find(|client| u32::try_from(client.id).ok() == Some(audio.from_client_id))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "audio caller {} not found in online clients",
+                    audio.from_client_id
+                )
+            })?;
+        let channel_group_id = self
+            .ts_adapter
+            .get_client_channel_group_id(audio.from_client_id)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "resolve audio caller {} channel group failed: {error}",
+                    audio.from_client_id
+                )
+            })?;
+        let groups: Vec<u32> = caller
+            .server_groups
+            .iter()
+            .filter_map(|group| group.parse().ok())
+            .collect();
+        debug!(
+            "Resolved audio caller '{}' from online list: clid={}",
+            audio.from_client_name, caller.id
+        );
+        Ok(CallerContext {
             caller_id: audio.from_client_id,
-            caller_name: audio.from_client_name.clone(),
-            groups: vec![],
-            channel_group_id: 0,
-            channel_id: 0,
+            caller_uid: caller.uid.clone(),
+            caller_name: caller.nickname.clone(),
+            groups,
+            channel_group_id,
+            channel_id: caller.channel_id,
             reply_target_mode,
             reply_target_client_id,
-        }
+        })
     }
 
     fn should_ignore_chat(&self, chat: &voicev1::ChatEvent, caller_id: u32) -> bool {
-        if chat.invoker_name == self.config.bot.nickname {
+        if chat.invoker_name == self.config.bot.nickname
+            || self.is_music_bot_name(&chat.invoker_name)
+        {
             return true;
         }
         let bot_clid = self.ts_adapter.get_bot_clid();
         bot_clid != 0 && caller_id == bot_clid
     }
 
-    async fn execute_skill(&self, call: &ToolCall, ctx: &CallerContext) -> String {
+    fn is_music_bot_name(&self, name: &str) -> bool {
+        self.config.music_backend.as_ref().is_some_and(|config| {
+            !config.musicbot_name.is_empty()
+                && name
+                    .to_ascii_lowercase()
+                    .contains(&config.musicbot_name.to_ascii_lowercase())
+        })
+    }
+
+    async fn resolve_audio_chunk_caller(
+        &self,
+        audio: &voicev1::AudioFrameEvent,
+        speaker_client_id: u32,
+        speaker_name: &str,
+    ) -> Result<CallerContext> {
+        let mut ctx = self.resolve_caller_from_audio(audio).await?;
+        if ctx.caller_id != speaker_client_id {
+            anyhow::bail!(
+                "audio caller changed from {} to {} while resolving ACL",
+                ctx.caller_id,
+                speaker_client_id
+            );
+        }
+        if !speaker_name.is_empty() {
+            ctx.caller_name = speaker_name.to_string();
+        }
+        Ok(ctx)
+    }
+
+    async fn execute_skill(
+        &self,
+        call: &ToolCall,
+        ctx: &CallerContext,
+        allowed_skills: &[String],
+    ) -> String {
         let exec_ctx = ExecutionContext {
             adapter: self.ts_adapter.clone(),
             caller_id: ctx.caller_id,
@@ -252,7 +401,9 @@ impl VoiceRouter {
             gate: self.gate.clone(),
             config: self.config.clone(),
         };
-        self.registry.execute_skill(call, exec_ctx, None).await
+        self.registry
+            .execute_skill(call, exec_ctx, allowed_skills, None)
+            .await
     }
 
     async fn handle_chat_event(
@@ -260,53 +411,55 @@ impl VoiceRouter {
         client: &mut VoiceServiceClient<Channel>,
         chat: voicev1::ChatEvent,
     ) -> Result<()> {
-        let ctx = self.resolve_caller_from_chat(&chat).await;
+        let ctx = self.resolve_caller_from_chat(&chat).await?;
         if self.should_ignore_chat(&chat, ctx.caller_id) || !chat.should_trigger_llm {
             return Ok(());
         }
         let Some(clean_text) = preprocess_text_message(&chat.message) else {
             return Ok(());
         };
+        let session_lock = self.session_locks.for_uid(&ctx.caller_uid);
+        let _session_guard = session_lock.lock().await;
         self.handle_user_input(client, ctx, clean_text).await
     }
 
-    async fn handle_audio_event(
+    async fn process_audio_frame(
+        &self,
+        audio: &voicev1::AudioFrameEvent,
+    ) -> Result<Option<SpeechChunk>> {
+        let bot_clid = self.ts_adapter.get_bot_clid();
+        if bot_clid != 0 && audio.from_client_id == bot_clid {
+            return Ok(None);
+        }
+        if self.is_music_bot_name(&audio.from_client_name) {
+            return Ok(None);
+        }
+
+        let mut guard = self.audio_pipeline.lock().await;
+        let Some(pipeline) = guard.as_mut() else {
+            return Ok(None);
+        };
+        pipeline.process_audio_frame(audio)
+    }
+
+    async fn handle_audio_chunk(
         &self,
         client: &mut VoiceServiceClient<Channel>,
         audio: voicev1::AudioFrameEvent,
+        chunk: SpeechChunk,
     ) -> Result<()> {
-        let bot_clid = self.ts_adapter.get_bot_clid();
-        if bot_clid != 0 && audio.from_client_id == bot_clid {
+        let ctx = self
+            .resolve_audio_chunk_caller(&audio, chunk.speaker_client_id, &chunk.speaker_name)
+            .await?;
+        if self.is_music_bot_name(&ctx.caller_name) {
             return Ok(());
         }
-        let musicbot_name = self
-            .config
-            .music_backend
-            .as_ref()
-            .map_or("", |c| c.musicbot_name.as_str());
-        if !musicbot_name.is_empty()
-            && audio
-                .from_client_name
-                .to_ascii_lowercase()
-                .contains(&musicbot_name.to_ascii_lowercase())
-        {
-            return Ok(());
-        }
+        let session_lock = self.session_locks.for_uid(&ctx.caller_uid);
+        let _session_guard = session_lock.lock().await;
 
         if self.config.llm.omni_model {
-            return self.handle_omni_audio_event(client, audio).await;
+            return self.handle_omni_audio_chunk(client, ctx, chunk).await;
         }
-
-        let chunk = {
-            let mut guard = self.audio_pipeline.lock().await;
-            let Some(pipeline) = guard.as_mut() else {
-                return Ok(());
-            };
-            pipeline.process_audio_frame(&audio)?
-        };
-        let Some(chunk) = chunk else {
-            return Ok(());
-        };
 
         let Some(speech_provider) = self.speech_provider.as_ref() else {
             return Ok(());
@@ -323,40 +476,25 @@ impl VoiceRouter {
             return Ok(());
         };
 
-        let mut ctx = self.resolve_caller_from_audio(&audio).await;
-        ctx.caller_name = chunk.speaker_name;
-        ctx.caller_id = chunk.speaker_client_id;
         self.handle_user_input(client, ctx, text).await
     }
 
-    async fn handle_omni_audio_event(
+    async fn handle_omni_audio_chunk(
         &self,
         client: &mut VoiceServiceClient<Channel>,
-        audio: voicev1::AudioFrameEvent,
+        ctx: CallerContext,
+        chunk: SpeechChunk,
     ) -> Result<()> {
-        let chunk = {
-            let mut guard = self.audio_pipeline.lock().await;
-            let Some(pipeline) = guard.as_mut() else {
-                return Ok(());
-            };
-            pipeline.process_audio_frame(&audio)?
-        };
-        let Some(chunk) = chunk else {
-            return Ok(());
-        };
-
         let wav_bytes = pcm16_mono_to_wav_bytes(&chunk.pcm16_mono_16k, 16_000);
         let audio_base64 = BASE64.encode(&wav_bytes);
         let audio_data = format!("data:audio/wav;base64,{}", audio_base64);
-        let mut ctx = self.resolve_caller_from_audio(&audio).await;
-        ctx.caller_name = chunk.speaker_name;
-        ctx.caller_id = chunk.speaker_client_id;
 
-        let (mut messages, tools, session_source) =
+        let (mut messages, tools, allowed_skills, session_source) =
             self.build_omni_llm_request(&ctx, audio_data).await;
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
+            allowed_skills: &allowed_skills,
         };
         let callbacks = if self.is_tts_effectively_enabled() {
             Some(self.build_tts_callbacks().await?)
@@ -371,7 +509,12 @@ impl VoiceRouter {
         {
             Ok(result) => {
                 if !result.content.is_empty() {
-                    info!("[TS&TTS] LLM final reply: {}", &result.content);
+                    info!(
+                        event = "voice.llm.reply",
+                        caller_uid = %ctx.caller_uid,
+                        reply_chars = result.content.chars().count(),
+                        "Voice LLM reply generated"
+                    );
                     self.send_reply(client, &ctx, &result.content).await?;
                     self.llm
                         .save_turn(&session_source, "[Audio message]".into(), result.content);
@@ -401,13 +544,19 @@ impl VoiceRouter {
         ctx: CallerContext,
         user_msg: String,
     ) -> Result<()> {
-        info!(event = "voice.chat.user_message", invoker = %ctx.caller_name, clid = ctx.caller_id, message = %self.truncate_for_log(&user_msg));
+        info!(
+            event = "voice.user_message",
+            caller_uid = %ctx.caller_uid,
+            message_chars = user_msg.chars().count(),
+            "Voice user message received"
+        );
 
-        let (mut messages, tools, session_source) =
+        let (mut messages, tools, allowed_skills, session_source) =
             self.build_llm_request(&ctx, user_msg.clone()).await;
         let executor = SkillExecutor {
             router: self,
             ctx: &ctx,
+            allowed_skills: &allowed_skills,
         };
 
         let callbacks = if self.is_tts_effectively_enabled() {
@@ -439,7 +588,12 @@ impl VoiceRouter {
         };
 
         if !result.content.is_empty() {
-            info!("[TS&TTS] LLM final reply: {}", &result.content);
+            info!(
+                event = "voice.llm.reply",
+                caller_uid = %ctx.caller_uid,
+                reply_chars = result.content.chars().count(),
+                "Voice LLM reply generated"
+            );
             self.send_reply(client, &ctx, &result.content).await?;
             self.llm
                 .save_turn(&session_source, user_msg, result.content);
@@ -534,7 +688,7 @@ impl VoiceRouter {
         let on_turn_end_shared = shared_tx.clone();
         let on_turn_end_chunker = chunker.clone();
         let on_turn_end = move |finish_reason: &str| {
-            if finish_reason == "stop" {
+            if should_close_tts_turn(finish_reason) {
                 let Ok(mut chunker_guard) = on_turn_end_chunker.lock() else {
                     return;
                 };
@@ -560,7 +714,7 @@ impl VoiceRouter {
     async fn build_llm_base_context(
         &self,
         ctx: &CallerContext,
-    ) -> (String, String, Vec<serde_json::Value>) {
+    ) -> (String, String, Vec<serde_json::Value>, Vec<String>) {
         let system_prompt = self.prompts.system.content.clone();
 
         let online_clients = match self.ts_adapter.list_clients().await {
@@ -587,7 +741,7 @@ Online: {}"#,
             .gate
             .get_allowed_skills(&ctx.groups, ctx.channel_group_id);
         let tools = self.registry.to_tool_schemas(&allowed_skills);
-        (system_prompt, user_ctx, tools)
+        (system_prompt, user_ctx, tools, allowed_skills)
     }
 
     async fn build_llm_request(
@@ -597,16 +751,18 @@ Online: {}"#,
     ) -> (
         Vec<serde_json::Value>,
         Vec<serde_json::Value>,
+        Vec<String>,
         SessionSource,
     ) {
-        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx).await;
+        let (system_prompt, user_ctx, tools, allowed_skills) =
+            self.build_llm_base_context(ctx).await;
         let source = SessionSource::Headless {
-            caller_id: ctx.caller_id,
+            uid: ctx.caller_uid.clone(),
         };
         let messages = self
             .llm
             .build_messages(&source, &system_prompt, &user_ctx, &user_msg);
-        (messages, tools, source)
+        (messages, tools, allowed_skills, source)
     }
 
     async fn build_omni_llm_request(
@@ -616,17 +772,19 @@ Online: {}"#,
     ) -> (
         Vec<serde_json::Value>,
         Vec<serde_json::Value>,
+        Vec<String>,
         SessionSource,
     ) {
-        let (system_prompt, user_ctx, tools) = self.build_llm_base_context(ctx).await;
+        let (system_prompt, user_ctx, tools, allowed_skills) =
+            self.build_llm_base_context(ctx).await;
         let source = SessionSource::Headless {
-            caller_id: ctx.caller_id,
+            uid: ctx.caller_uid.clone(),
         };
         let content = vec![json!({ "type": "input_audio", "input_audio": { "data": audio_data } })];
         let messages = self
             .llm
             .build_omni_messages(&source, &system_prompt, &user_ctx, content);
-        (messages, tools, source)
+        (messages, tools, allowed_skills, source)
     }
 
     async fn send_reply(
@@ -640,7 +798,13 @@ Online: {}"#,
             target_mode: ctx.reply_target_mode,
             target_client_id: ctx.reply_target_client_id,
         };
-        let _ = client.send_notice(tonic::Request::new(req)).await?;
+        let response = client
+            .send_notice(tonic::Request::new(req))
+            .await?
+            .into_inner();
+        if !response.ok {
+            anyhow::bail!("voice notice rejected: {}", response.message);
+        }
         Ok(())
     }
 }
@@ -698,5 +862,80 @@ impl StreamingSentenceChunker {
         let out = text.to_string();
         self.buffer.clear();
         Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn session_locks_serialize_only_the_same_uid() {
+        let locks = SessionLocks::default();
+        let first = locks.for_uid("uid-1");
+        let first_guard = first.lock().await;
+        let same = locks.for_uid("uid-1");
+        let other = locks.for_uid("uid-2");
+
+        assert!(same.try_lock().is_err());
+        assert!(other.try_lock().is_ok());
+
+        drop(first_guard);
+        assert!(same.try_lock().is_ok());
+    }
+
+    #[tokio::test]
+    async fn managed_tasks_are_cancelled_on_router_exit() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let marker = DropMarker(dropped.clone());
+        let mut tasks = JoinSet::new();
+        tasks.spawn(async move {
+            let _marker = marker;
+            std::future::pending::<ManagedTaskExit>().await
+        });
+        tokio::task::yield_now().await;
+
+        abort_managed_tasks(&mut tasks).await;
+
+        assert!(dropped.load(Ordering::SeqCst));
+        assert!(tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn audio_limit_waits_instead_of_dropping_work() {
+        let limit = Arc::new(Semaphore::new(AUDIO_MAX_IN_FLIGHT));
+        let mut permits = Vec::new();
+        for _ in 0..AUDIO_MAX_IN_FLIGHT {
+            permits.push(acquire_audio_slot(limit.clone()).await.unwrap());
+        }
+
+        let waiter = tokio::spawn(acquire_audio_slot(limit.clone()));
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(permits.pop());
+        let permit = waiter.await.unwrap().unwrap();
+        assert_eq!(limit.available_permits(), 0);
+
+        drop(permit);
+        drop(permits);
+        assert_eq!(limit.available_permits(), AUDIO_MAX_IN_FLIGHT);
+    }
+
+    #[test]
+    fn tts_closes_for_every_non_tool_call_finish_reason() {
+        assert!(!should_close_tts_turn("tool_calls"));
+        for finish_reason in ["stop", "length", "content_filter", "function_call", ""] {
+            assert!(should_close_tts_turn(finish_reason));
+        }
     }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -17,6 +17,21 @@ use serde_json::Value;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
+pub(crate) fn required_u32(args: &Value, name: &str) -> Result<u32> {
+    let value = args
+        .get(name)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow::anyhow!("Parameter '{}' must be a non-negative integer", name))?;
+    u32::try_from(value)
+        .map_err(|_| anyhow::anyhow!("Parameter '{}' exceeds the supported range", name))
+}
+
+pub(crate) fn is_skill_allowed(name: &str, allowed_skills: &[String]) -> bool {
+    allowed_skills
+        .iter()
+        .any(|allowed| allowed == "*" || allowed == name)
+}
+
 // ─────────────────────────────────────────────
 // 平台类型枚举
 // ─────────────────────────────────────────────
@@ -49,6 +64,7 @@ pub struct NcExecutionContext {
     pub adapter: Arc<NapCatAdapter>,
     pub caller_id: i64,
     pub caller_name: String,
+    pub caller_groups: Vec<u32>,
     pub caller_group_id: Option<i64>,
     pub gate: Arc<PermissionGate>,
     pub config: Arc<AppConfig>,
@@ -97,7 +113,7 @@ impl UnifiedExecutionContext {
             caller_id: 0,
             caller_id_nc: ctx.caller_id,
             caller_name: ctx.caller_name.clone(),
-            caller_groups: vec![],
+            caller_groups: ctx.caller_groups.clone(),
             caller_channel_group_id: 0,
             nc_group_id: ctx.caller_group_id,
             gate: ctx.gate.clone(),
@@ -126,6 +142,21 @@ impl UnifiedExecutionContext {
             caller_name: self.caller_name.clone(),
             caller_groups: self.caller_groups.clone(),
             caller_channel_group_id: self.caller_channel_group_id,
+            gate: self.gate.clone(),
+            config: self.config.clone(),
+        })
+    }
+
+    pub fn to_nc_ctx(&self) -> Result<NcExecutionContext> {
+        Ok(NcExecutionContext {
+            adapter: self
+                .nc_adapter
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("NapCat adapter not available"))?,
+            caller_id: self.caller_id_nc,
+            caller_name: self.caller_name.clone(),
+            caller_groups: self.caller_groups.clone(),
+            caller_group_id: self.nc_group_id,
             gate: self.gate.clone(),
             config: self.config.clone(),
         })
@@ -171,13 +202,12 @@ pub trait Skill: Send + Sync {
         ))
     }
 
-    /// 统一执行（支持跨平台，默认为 nil 表示不支持）
-    async fn execute_unified(&self, args: Value, _ctx: &UnifiedExecutionContext) -> Result<Value> {
-        let _ = args;
-        Err(anyhow::anyhow!(
-            "Skill '{}' does not support unified execution",
-            self.name()
-        ))
+    /// 统一执行，默认分派到当前平台的原生实现
+    async fn execute_unified(&self, args: Value, ctx: &UnifiedExecutionContext) -> Result<Value> {
+        match ctx.platform {
+            Platform::TeamSpeak => self.execute(args, &ctx.to_ts_ctx()?).await,
+            Platform::NapCat => self.execute_nc(args, &ctx.to_nc_ctx()?).await,
+        }
     }
 
     /// 是否应该注册此 skill，默认 true。覆盖返回 false 可阻止注册。
@@ -220,30 +250,36 @@ impl SkillRegistry {
     }
 
     pub fn list_skills(&self) -> Vec<String> {
-        self.skills.iter().map(|s| s.key().clone()).collect()
+        let mut skills: Vec<_> = self
+            .skills
+            .iter()
+            .map(|skill| skill.key().clone())
+            .collect();
+        skills.sort_unstable();
+        skills
     }
 
     pub async fn execute_skill(
         &self,
         call: &ToolCall,
         exec_ctx: ExecutionContext,
+        allowed_skills: &[String],
         nc_adapter: Option<Arc<NapCatAdapter>>,
     ) -> String {
+        if !is_skill_allowed(&call.name, allowed_skills) {
+            warn!(skill = %call.name, "Skill execution denied by ACL");
+            return "Skill execution denied".to_string();
+        }
+
         if let Some(skill) = self.get(&call.name) {
             let ts_adapter = Some(exec_ctx.adapter.clone());
             let unified_ctx = UnifiedExecutionContext::from_ts(&exec_ctx)
                 .with_cross_adapters(ts_adapter, nc_adapter);
 
-            let args = call.arguments.clone();
-            let result = match skill.execute_unified(args.clone(), &unified_ctx).await {
-                Ok(val) => Ok(val),
-                Err(unified_err) => {
-                    debug!(skill = %call.name, error = %unified_err, "Falling back to TS execution");
-                    skill.execute(args, &exec_ctx).await
-                }
-            };
-
-            match result {
+            match skill
+                .execute_unified(call.arguments.clone(), &unified_ctx)
+                .await
+            {
                 Ok(val) => val.to_string(),
                 Err(e) => {
                     error!(skill = %call.name, error = %e, "Skill execution failed");
@@ -257,23 +293,27 @@ impl SkillRegistry {
     }
 
     pub fn to_tool_schemas(&self, allowed_skills: &[String]) -> Vec<Value> {
-        self.skills
+        let mut schemas: Vec<_> = self
+            .skills
             .iter()
-            .filter(|s| {
-                allowed_skills.contains(&"*".to_string())
-                    || allowed_skills.contains(&s.key().clone())
-            })
-            .map(|s| {
+            .filter(|skill| is_skill_allowed(skill.key(), allowed_skills))
+            .map(|skill| {
                 serde_json::json!({
                     "type": "function",
                     "function": {
-                        "name": s.name(),
-                        "description": s.description(),
-                        "parameters": s.parameters()
+                        "name": skill.name(),
+                        "description": skill.description(),
+                        "parameters": skill.parameters()
                     }
                 })
             })
-            .collect()
+            .collect();
+        schemas.sort_unstable_by(|left, right| {
+            left["function"]["name"]
+                .as_str()
+                .cmp(&right["function"]["name"].as_str())
+        });
+        schemas
     }
 }
 
@@ -282,12 +322,115 @@ impl SkillRegistry {
 // ─────────────────────────────────────────────
 
 static DEFAULT_SKILLS: &[(&str, SkillFactory)] = &[
-    ("poke",         |_| Box::new(communication::PokeClient) as Box<dyn Skill>),
-    ("send_message", |_| Box::new(communication::SendMessage) as Box<dyn Skill>),
-    ("kick",         |_| Box::new(moderation::KickClient) as Box<dyn Skill>),
-    ("ban",          |_| Box::new(moderation::BanClient) as Box<dyn Skill>),
-    ("move",         |_| Box::new(moderation::MoveClient) as Box<dyn Skill>),
-    ("client_info",  |_| Box::new(information::GetClientInfo) as Box<dyn Skill>),
-    ("web_search",   |_| Box::new(web_search::WebSearch) as Box<dyn Skill>),
-    ("music",       |ctx| Box::new(music::MusicControl::new(ctx.music_backend_config())) as Box<dyn Skill>),
+    ("poke_client", |_| {
+        Box::new(communication::PokeClient) as Box<dyn Skill>
+    }),
+    ("send_message", |_| {
+        Box::new(communication::SendMessage) as Box<dyn Skill>
+    }),
+    ("kick_client", |_| {
+        Box::new(moderation::KickClient) as Box<dyn Skill>
+    }),
+    ("ban_client", |_| {
+        Box::new(moderation::BanClient) as Box<dyn Skill>
+    }),
+    ("move_client", |_| {
+        Box::new(moderation::MoveClient) as Box<dyn Skill>
+    }),
+    ("get_client_info", |_| {
+        Box::new(information::GetClientInfo) as Box<dyn Skill>
+    }),
+    ("web_search", |_| {
+        Box::new(web_search::WebSearch) as Box<dyn Skill>
+    }),
+    ("music_control", |ctx| {
+        Box::new(music::MusicControl::new(ctx.music_backend_config())) as Box<dyn Skill>
+    }),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AclConfig;
+    use serde_json::json;
+
+    struct TestSkill(&'static str);
+
+    #[async_trait]
+    impl Skill for TestSkill {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+
+        fn description(&self) -> &'static str {
+            "test"
+        }
+
+        fn parameters(&self) -> Value {
+            json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: Value, _ctx: &ExecutionContext) -> Result<Value> {
+            Ok(json!("ts"))
+        }
+    }
+
+    fn unified_context(platform: Platform) -> UnifiedExecutionContext {
+        UnifiedExecutionContext {
+            platform,
+            ts_adapter: None,
+            nc_adapter: None,
+            caller_id: 1,
+            caller_id_nc: 2,
+            caller_name: "test".to_string(),
+            caller_groups: vec![],
+            caller_channel_group_id: 0,
+            nc_group_id: None,
+            gate: Arc::new(PermissionGate::new(AclConfig::default())),
+            config: Arc::new(AppConfig::default()),
+        }
+    }
+
+    #[test]
+    fn required_u32_rejects_overflow() {
+        let args = json!({"id": u64::from(u32::MAX) + 1});
+        assert!(required_u32(&args, "id").is_err());
+    }
+
+    #[test]
+    fn tool_schemas_are_filtered_and_sorted() {
+        let registry = SkillRegistry::default();
+        registry.register(Box::new(TestSkill("zeta")));
+        registry.register(Box::new(TestSkill("alpha")));
+
+        let schemas = registry.to_tool_schemas(&["*".to_string()]);
+        let names: Vec<_> = schemas
+            .iter()
+            .map(|schema| schema["function"]["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, ["alpha", "zeta"]);
+
+        let schemas = registry.to_tool_schemas(&["zeta".to_string()]);
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0]["function"]["name"], "zeta");
+        assert!(is_skill_allowed("zeta", &["zeta".to_string()]));
+        assert!(!is_skill_allowed("alpha", &["zeta".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn unified_execution_uses_platform_native_context() {
+        let skill = TestSkill("test");
+
+        let ts_error = skill
+            .execute_unified(json!({}), &unified_context(Platform::TeamSpeak))
+            .await
+            .unwrap_err();
+        assert_eq!(ts_error.to_string(), "TeamSpeak adapter not available");
+
+        let nc_error = skill
+            .execute_unified(json!({}), &unified_context(Platform::NapCat))
+            .await
+            .unwrap_err();
+        assert_eq!(nc_error.to_string(), "NapCat adapter not available");
+    }
+}

--- a/src/skills/communication.rs
+++ b/src/skills/communication.rs
@@ -1,8 +1,19 @@
-use crate::skills::{ExecutionContext, Platform, Skill, UnifiedExecutionContext};
+use crate::skills::{required_u32, ExecutionContext, Platform, Skill, UnifiedExecutionContext};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use tracing::info;
+
+fn required_message<'a>(args: &'a Value, name: &str) -> Result<&'a str> {
+    let message = args
+        .get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("Missing required parameter: {}", name))?;
+    if message.trim().is_empty() {
+        return Err(anyhow::anyhow!("{} cannot be empty", name));
+    }
+    Ok(message)
+}
 
 pub struct PokeClient;
 
@@ -25,11 +36,8 @@ impl Skill for PokeClient {
         })
     }
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clid = args["clid"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-            as u32;
-        let msg = args["msg"].as_str().unwrap_or("Poke!");
+        let clid = required_u32(&args, "clid")?;
+        let msg = required_message(&args, "msg")?;
 
         ctx.adapter.poke(clid, msg).await?;
         Ok(json!({"status": "ok", "message": "Poke sent"}))
@@ -38,7 +46,7 @@ impl Skill for PokeClient {
     async fn execute_unified(&self, args: Value, ctx: &UnifiedExecutionContext) -> Result<Value> {
         info!("PokeClient: unified execution, platform={:?}", ctx.platform);
 
-        let msg = args["msg"].as_str().unwrap_or("Poke!");
+        let msg = required_message(&args, "msg")?;
 
         match ctx.platform {
             Platform::TeamSpeak => {
@@ -51,10 +59,7 @@ impl Skill for PokeClient {
                     .as_ref()
                     .ok_or_else(|| anyhow::anyhow!("TeamSpeak adapter not available"))?;
 
-                let clid = args["clid"]
-                    .as_u64()
-                    .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-                    as u32;
+                let clid = required_u32(&args, "clid")?;
 
                 ts_adapter.poke(clid, msg).await?;
 
@@ -120,19 +125,13 @@ impl Skill for SendMessage {
     }
 
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let msg = args["msg"].as_str().unwrap_or("");
-        if msg.is_empty() {
-            return Err(anyhow::anyhow!("Message content cannot be empty"));
-        }
+        let msg = required_message(&args, "msg")?;
 
         let mode = args["mode"].as_str().unwrap_or("");
 
         let (targetmode, target) = match mode {
             "private" => {
-                let clid = args["clid"]
-                    .as_u64()
-                    .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-                    as u32;
+                let clid = required_u32(&args, "clid")?;
 
                 (1, clid)
             }
@@ -161,10 +160,7 @@ impl Skill for SendMessage {
             ctx.platform
         );
 
-        let msg = args["msg"].as_str().unwrap_or("");
-        if msg.is_empty() {
-            return Err(anyhow::anyhow!("Message content cannot be empty"));
-        }
+        let msg = required_message(&args, "msg")?;
 
         let mode = args["mode"].as_str().unwrap_or("");
         let ts_route = args["ts_route"].as_bool().unwrap_or(false);
@@ -227,15 +223,8 @@ impl Skill for SendMessage {
                             anyhow::anyhow!("TeamSpeak adapter not available for ts_route=true")
                         })?;
                         // NC 请求 → TS 执行
-                        let target = args["clid"].as_u64().map(|v| v as u32);
-
                         let (targetmode, target_id) = match mode {
-                            "private" => {
-                                let clid = target.ok_or_else(|| {
-                                    anyhow::anyhow!("Missing required parameter: clid")
-                                })?;
-                                (1, clid)
-                            }
+                            "private" => (1, required_u32(&args, "clid")?),
                             "channel" => (2, 0),
                             "server" => (3, 0),
                             _ => {

--- a/src/skills/information.rs
+++ b/src/skills/information.rs
@@ -1,4 +1,4 @@
-use crate::skills::{ExecutionContext, Platform, Skill, UnifiedExecutionContext};
+use crate::skills::{required_u32, ExecutionContext, Platform, Skill, UnifiedExecutionContext};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -24,10 +24,7 @@ impl Skill for GetClientInfo {
         })
     }
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clid = args["clid"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-            as u32;
+        let clid = required_u32(&args, "clid")?;
 
         let mut info = ctx.adapter.get_client_info(clid).await?;
 
@@ -105,10 +102,7 @@ impl Skill for GetClientInfo {
                 return self.execute(args.clone(), &ts_ctx).await;
             }
             Platform::NapCat => {
-                let clid = args["clid"]
-                    .as_u64()
-                    .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-                    as u32;
+                let clid = required_u32(&args, "clid")?;
 
                 let ts_adapter = ctx
                     .ts_adapter
@@ -118,7 +112,7 @@ impl Skill for GetClientInfo {
                 let clients = ts_adapter.list_clients().await?;
                 let client = clients
                     .iter()
-                    .find(|c| c.id as u32 == clid)
+                    .find(|c| u32::try_from(c.id).ok() == Some(clid))
                     .ok_or_else(|| {
                         anyhow::anyhow!("Client {} is not online or does not exist", clid)
                     })?;

--- a/src/skills/moderation.rs
+++ b/src/skills/moderation.rs
@@ -1,5 +1,5 @@
-use crate::skills::{ExecutionContext, Skill, UnifiedExecutionContext};
-use anyhow::Result;
+use crate::skills::{required_u32, ExecutionContext, Skill, UnifiedExecutionContext};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use tracing::info;
@@ -14,16 +14,19 @@ async fn validate_target(ctx: &ExecutionContext, clid: u32) -> Result<Vec<u32>> 
 
     // 获取目标的组信息（实时查询）
     let clients = ctx.adapter.list_clients().await?;
-    let target_groups: Vec<u32> = clients
+    let target = clients
         .iter()
-        .find(|c| c.id as u32 == clid)
-        .map(|c| {
-            c.server_groups
-                .iter()
-                .filter_map(|g| g.parse().ok())
-                .collect()
+        .find(|c| u32::try_from(c.id).ok() == Some(clid))
+        .ok_or_else(|| anyhow::anyhow!("Client {} is not online or does not exist", clid))?;
+    let target_groups = target
+        .server_groups
+        .iter()
+        .map(|group| {
+            group
+                .parse::<u32>()
+                .with_context(|| format!("Invalid server group ID '{}'", group))
         })
-        .unwrap_or_default();
+        .collect::<Result<Vec<_>>>()?;
 
     // 检查是否可以对目标执行操作
     if !ctx.gate.can_target(
@@ -76,9 +79,7 @@ impl Skill for KickClient {
         })
     }
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clid = args["clid"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing clid"))? as u32;
+        let clid = required_u32(&args, "clid")?;
         let reason = args["reason"].as_str().unwrap_or("Kicked by bot");
 
         // 权限和自操作检查
@@ -117,9 +118,7 @@ impl Skill for BanClient {
         })
     }
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clid = args["clid"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing clid"))? as u32;
+        let clid = required_u32(&args, "clid")?;
         let time = args["time"]
             .as_u64()
             .ok_or_else(|| anyhow::anyhow!("Missing time"))?;
@@ -163,14 +162,8 @@ impl Skill for MoveClient {
     }
 
     async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let clid = args["clid"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: clid"))?
-            as u32;
-        let channel_id = args["channel_id"]
-            .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Missing required parameter: channel_id"))?
-            as u32;
+        let clid = required_u32(&args, "clid")?;
+        let channel_id = required_u32(&args, "channel_id")?;
 
         validate_target(ctx, clid).await?;
 

--- a/src/skills/music.rs
+++ b/src/skills/music.rs
@@ -15,12 +15,18 @@ async fn dispatch_backend(
     cfg: &MusicBackendConfig,
     ts_ctx: Option<&ExecutionContext>,
 ) -> Result<Value> {
-    let ctx = ts_ctx
-        .ok_or_else(|| anyhow::anyhow!("{} backend requires TeamSpeak context", cfg.backend))?;
     match cfg.backend.as_str() {
         "tsbot_backend" => tsbot_http::execute(action, args, &cfg.base_url).await,
-        "ts3audiobot" => ts3audiobot::execute(action, args, ctx).await,
-        "tsmusicbot" => tsmusicbot::execute(action, args, ctx).await,
+        "ts3audiobot" => {
+            let ctx = ts_ctx
+                .ok_or_else(|| anyhow::anyhow!("ts3audiobot backend requires TeamSpeak context"))?;
+            ts3audiobot::execute(action, args, ctx).await
+        }
+        "tsmusicbot" => {
+            let ctx = ts_ctx
+                .ok_or_else(|| anyhow::anyhow!("tsmusicbot backend requires TeamSpeak context"))?;
+            tsmusicbot::execute(action, args, ctx).await
+        }
         _ => Err(anyhow::anyhow!(
             "Unknown music backend '{}', expected one of: ts3audiobot, tsmusicbot, tsbot_backend",
             cfg.backend
@@ -34,9 +40,7 @@ pub struct MusicControl {
 
 impl MusicControl {
     pub fn new(cfg: Option<&MusicBackendConfig>) -> Self {
-        let backend = cfg
-            .map(|c| c.backend.as_str())
-            .unwrap_or("");
+        let backend = cfg.map(|c| c.backend.as_str()).unwrap_or("");
         Self {
             backend: backend.to_string(),
         }
@@ -56,7 +60,7 @@ impl Skill for MusicControl {
     fn description(&self) -> &'static str {
         match self.backend.as_str() {
             "ts3audiobot" => "Control the TS3AudioBot music player via chat commands. \
-                             Use ts_* actions to play songs, manage playlists, and switch modes.",
+                             Play songs, manage playlists, and switch modes.",
             "tsmusicbot" => "Control the TSMusicBot music player via chat commands. \
                             Supports play, pause, resume, next/prev, stop, volume, mode, queue, search, add, playlist, fm.",
             "tsbot_backend" => "Control the NeteaseTSBot music player. Search and play songs from NetEase Music and QQ Music, \
@@ -79,11 +83,10 @@ impl Skill for MusicControl {
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing action"))?;
 
-        let cfg = ctx
-            .config
-            .music_backend
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("MusicControl registered but music_backend is None"))?;
+        let cfg =
+            ctx.config.music_backend.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("MusicControl registered but music_backend is None")
+            })?;
         dispatch_backend(action, &args, cfg, Some(ctx)).await
     }
 
@@ -97,23 +100,20 @@ impl Skill for MusicControl {
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing action"))?;
 
-        let cfg = ctx
-            .config
-            .music_backend
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("MusicControl registered but music_backend is None"))?;
+        let cfg =
+            ctx.config.music_backend.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("MusicControl registered but music_backend is None")
+            })?;
 
-        match ctx.platform {
-            crate::skills::Platform::TeamSpeak => {
-                let ts_ctx = ctx.to_ts_ctx()?;
-                dispatch_backend(action, &args, cfg, Some(&ts_ctx)).await
-            }
-            crate::skills::Platform::NapCat => {
-                let ts_ctx = ctx.to_ts_ctx()?;
+        let ts_ctx = if cfg.backend == "tsbot_backend" {
+            None
+        } else {
+            if ctx.platform == crate::skills::Platform::NapCat {
                 info!("MusicControl: NC request forwarded to TS");
-                dispatch_backend(action, &args, cfg, Some(&ts_ctx)).await
             }
-        }
+            Some(ctx.to_ts_ctx()?)
+        };
+        dispatch_backend(action, &args, cfg, ts_ctx.as_ref()).await
     }
 }
 
@@ -231,15 +231,20 @@ fn tsbot_schema() -> Value {
             },
             "seek_time": {
                 "type": "number",
-                "description": "Seek position in seconds for 'seek' action."
+                "description": "Seek position in seconds for 'seek' action.",
+                "minimum": 0
             },
             "limit": {
                 "type": "integer",
-                "description": "Search result limit for 'search' action."
+                "description": "Search result limit for 'search' action.",
+                "minimum": 1,
+                "maximum": 50,
+                "default": 20
             },
             "repeat_mode": {
                 "type": "string",
-                "description": "Repeat mode for 'repeat' action: 'none', 'all', 'one'."
+                "description": "Repeat mode for 'repeat' action.",
+                "enum": ["none", "all", "one"]
             },
             "shuffle_enabled": {
                 "type": "boolean",
@@ -247,7 +252,9 @@ fn tsbot_schema() -> Value {
             },
             "volume_percent": {
                 "type": "integer",
-                "description": "Volume percentage (0-200) for 'volume' action."
+                "description": "Volume percentage for 'volume' action.",
+                "minimum": 0,
+                "maximum": 200
             },
             "fx_pan": {
                 "type": "number",

--- a/src/skills/music/ts3audiobot.rs
+++ b/src/skills/music/ts3audiobot.rs
@@ -1,6 +1,6 @@
 use crate::adapter::{TextMessageTarget, TsEvent};
 use crate::skills::ExecutionContext;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -58,23 +58,22 @@ pub(crate) async fn execute(action: &str, args: &Value, ctx: &ExecutionContext) 
                 .contains(&target_name.to_ascii_lowercase())
         })
         .ok_or_else(|| anyhow::anyhow!("Music bot '{}' not found online", target_name))?;
+    let audiobot_id =
+        u32::try_from(audiobot.id).context("Music bot returned an invalid client ID")?;
 
     let _guard = TS3AUDIOBOT_LOCK.lock().await;
 
     let mut ts_rx = ctx.adapter.subscribe();
 
     ctx.adapter
-        .send_text_message(1, audiobot.id as u32, &bot_cmd)
+        .send_text_message(1, audiobot_id, &bot_cmd)
         .await?;
 
     let reply = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             match ts_rx.recv().await {
                 Ok(TsEvent::TextMessage(msg))
-                    if msg
-                        .invoker_name
-                        .to_ascii_lowercase()
-                        .contains(&target_name.to_ascii_lowercase())
+                    if msg.invoker_id == audiobot_id
                         && msg.target_mode == TextMessageTarget::Private =>
                 {
                     return msg.message;

--- a/src/skills/music/tsbot_http.rs
+++ b/src/skills/music/tsbot_http.rs
@@ -29,42 +29,32 @@ impl HttpBackend {
     pub(crate) async fn post(&self, path: &str, body: Option<Value>) -> Result<Value> {
         let url = format!("{}{}", self.base_url, path);
         let req = self.client.post(&url);
-        let resp = if let Some(b) = body {
+        let req = if let Some(b) = body {
             req.json(&b)
         } else {
             req
-        }
-        .send()
-        .await?;
-
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            return Err(anyhow::anyhow!("HTTP {} from {}: {}", status, path, text));
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(json!({"raw": text})))
+        };
+        Self::send(req, path).await
     }
 
     pub(crate) async fn put(&self, path: &str, body: Value) -> Result<Value> {
         let url = format!("{}{}", self.base_url, path);
-        let resp = self.client.put(&url).json(&body).send().await?;
+        Self::send(self.client.put(&url).json(&body), path).await
+    }
+
+    async fn send(req: reqwest::RequestBuilder, path: &str) -> Result<Value> {
+        let resp = req.send().await?;
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
             return Err(anyhow::anyhow!("HTTP {} from {}: {}", status, path, text));
         }
-        Ok(serde_json::from_str(&text).unwrap_or(json!({"raw": text})))
+        Ok(serde_json::from_str(&text).unwrap_or_else(|_| json!({"raw": text})))
     }
 
     pub(crate) async fn get(&self, path: &str, query: &[(&str, &str)]) -> Result<Value> {
         let url = format!("{}{}", self.base_url, path);
-        let resp = self.client.get(&url).query(query).send().await?;
-        let status = resp.status();
-        let text = resp.text().await?;
-        if !status.is_success() {
-            return Err(anyhow::anyhow!("HTTP {} from {}: {}", status, path, text));
-        }
-        Ok(serde_json::from_str(&text).unwrap_or(json!({"raw": text})))
+        Self::send(self.client.get(&url).query(query), path).await
     }
 }
 
@@ -82,6 +72,9 @@ pub(crate) async fn execute(action: &str, args: &Value, base_url: &str) -> Resul
             let t = args["seek_time"]
                 .as_f64()
                 .ok_or_else(|| anyhow::anyhow!("Missing seek_time"))?;
+            if t < 0.0 {
+                return Err(anyhow::anyhow!("seek_time must be non-negative"));
+            }
             http.post("/voice/seek", Some(json!({"time": t}))).await
         }
 
@@ -89,7 +82,14 @@ pub(crate) async fn execute(action: &str, args: &Value, base_url: &str) -> Resul
             let kw = args["keywords"]
                 .as_str()
                 .ok_or_else(|| anyhow::anyhow!("Missing keywords"))?;
-            let limit = args["limit"].as_u64().unwrap_or(10).to_string();
+            if kw.trim().is_empty() {
+                return Err(anyhow::anyhow!("keywords cannot be empty"));
+            }
+            let limit = args["limit"].as_u64().unwrap_or(20);
+            if !(1..=50).contains(&limit) {
+                return Err(anyhow::anyhow!("limit must be between 1 and 50"));
+            }
+            let limit = limit.to_string();
             http.get("/search", &[("keywords", kw), ("limit", &limit)])
                 .await
         }
@@ -148,6 +148,11 @@ pub(crate) async fn execute(action: &str, args: &Value, base_url: &str) -> Resul
             let mode = args["repeat_mode"]
                 .as_str()
                 .ok_or_else(|| anyhow::anyhow!("Missing repeat_mode"))?;
+            if !matches!(mode, "none" | "all" | "one") {
+                return Err(anyhow::anyhow!(
+                    "repeat_mode must be one of: none, all, one"
+                ));
+            }
             http.post("/voice/repeat", Some(json!({"mode": mode})))
                 .await
         }
@@ -164,17 +169,30 @@ pub(crate) async fn execute(action: &str, args: &Value, base_url: &str) -> Resul
             let vol = args["volume_percent"]
                 .as_u64()
                 .ok_or_else(|| anyhow::anyhow!("Missing volume_percent"))?;
+            if vol > 200 {
+                return Err(anyhow::anyhow!("volume_percent must be between 0 and 200"));
+            }
             http.put("/voice/volume", json!({"volume_percent": vol}))
                 .await
         }
 
         "fx" => {
             let mut body = json!({});
-            if let Some(v) = args["fx_pan"].as_f64() { body["pan"] = json!(v); }
-            if let Some(v) = args["fx_width"].as_f64() { body["width"] = json!(v); }
-            if let Some(v) = args["fx_swap_lr"].as_bool() { body["swap_lr"] = json!(v); }
-            if let Some(v) = args["fx_bass_db"].as_f64() { body["bass_db"] = json!(v); }
-            if let Some(v) = args["fx_reverb_mix"].as_f64() { body["reverb_mix"] = json!(v); }
+            if let Some(v) = args["fx_pan"].as_f64() {
+                body["pan"] = json!(v);
+            }
+            if let Some(v) = args["fx_width"].as_f64() {
+                body["width"] = json!(v);
+            }
+            if let Some(v) = args["fx_swap_lr"].as_bool() {
+                body["swap_lr"] = json!(v);
+            }
+            if let Some(v) = args["fx_bass_db"].as_f64() {
+                body["bass_db"] = json!(v);
+            }
+            if let Some(v) = args["fx_reverb_mix"].as_f64() {
+                body["reverb_mix"] = json!(v);
+            }
             http.put("/voice/fx", body).await
         }
 

--- a/src/skills/music/tsmusicbot.rs
+++ b/src/skills/music/tsmusicbot.rs
@@ -1,6 +1,6 @@
 use crate::adapter::{TextMessageTarget, TsEvent};
 use crate::skills::ExecutionContext;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -68,25 +68,21 @@ pub(crate) async fn execute(action: &str, args: &Value, ctx: &ExecutionContext) 
                 .contains(&target_name.to_ascii_lowercase())
         })
         .ok_or_else(|| anyhow::anyhow!("Music bot '{}' not found online", target_name))?;
+    let audiobot_id =
+        u32::try_from(audiobot.id).context("Music bot returned an invalid client ID")?;
 
-    let mut ts_rx;
-    {
-        let _guard = TSMUSICBOT_LOCK.lock().await;
-        ts_rx = ctx.adapter.subscribe();
+    let _guard = TSMUSICBOT_LOCK.lock().await;
+    let mut ts_rx = ctx.adapter.subscribe();
 
-        ctx.adapter
-            .send_text_message(1, audiobot.id as u32, &bot_cmd)
-            .await?;
-    }
+    ctx.adapter
+        .send_text_message(1, audiobot_id, &bot_cmd)
+        .await?;
 
     let reply = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             match ts_rx.recv().await {
                 Ok(TsEvent::TextMessage(msg))
-                    if msg
-                        .invoker_name
-                        .to_ascii_lowercase()
-                        .contains(&target_name.to_ascii_lowercase())
+                    if msg.invoker_id == audiobot_id
                         && msg.target_mode == TextMessageTarget::Channel =>
                 {
                     return msg.message;
@@ -100,6 +96,8 @@ pub(crate) async fn execute(action: &str, args: &Value, ctx: &ExecutionContext) 
         }
     })
     .await;
+
+    drop(_guard);
 
     match reply {
         Ok(content) if !content.is_empty() => {

--- a/src/skills/web_search.rs
+++ b/src/skills/web_search.rs
@@ -57,8 +57,8 @@ async fn search_exa(query: &str, num_results: u8, search_type: &str) -> Result<S
     }
 
     for line in text.lines() {
-        if let Some(data) = line.strip_prefix("data: ") {
-            if let Some(result) = parse_payload(data.trim()) {
+        if let Some(data) = line.strip_prefix("data:") {
+            if let Some(result) = parse_payload(data.trim_start()) {
                 return Ok(result);
             }
         }
@@ -104,8 +104,7 @@ impl Skill for WebSearch {
         })
     }
 
-    async fn execute(&self, args: Value, ctx: &ExecutionContext) -> Result<Value> {
-        let _ = ctx;
+    async fn execute(&self, args: Value, _ctx: &ExecutionContext) -> Result<Value> {
         execute_search(args).await
     }
 
@@ -118,13 +117,28 @@ async fn execute_search(args: Value) -> Result<Value> {
     let query = args["query"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing required parameter: query"))?;
+    if query.trim().is_empty() {
+        return Err(anyhow::anyhow!("query cannot be empty"));
+    }
 
-    let num_results = args["numResults"]
-        .as_u64()
-        .unwrap_or(8)
-        .min(MAX_RESULTS as u64) as u8;
+    let num_results = match args.get("numResults") {
+        Some(value) => value
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("numResults must be an integer"))?,
+        None => 8,
+    };
+    if !(1..=u64::from(MAX_RESULTS)).contains(&num_results) {
+        return Err(anyhow::anyhow!(
+            "numResults must be between 1 and {}",
+            MAX_RESULTS
+        ));
+    }
+    let num_results = num_results as u8;
 
     let search_type = args["type"].as_str().unwrap_or("auto");
+    if !matches!(search_type, "auto" | "fast" | "deep") {
+        return Err(anyhow::anyhow!("type must be one of: auto, fast, deep"));
+    }
 
     debug!(query, num_results, search_type, "WebSearch executing");
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -16,6 +16,20 @@ sidebar_position: 3
 
 **查看完整配置示例**：[settings.toml](https://github.com/Dr1mH4X/TeamSpeakClaw/blob/main/examples/config/settings.toml)
 
+### LLM 配置
+
+`[llm]` 区段配置 OpenAI 兼容的 Chat Completions 接口：
+
+| 字段 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `api_key` | string | `""` | API 密钥；本地免鉴权服务可留空 |
+| `base_url` | string | `https://api.openai.com/v1` | API 基础 URL，仅支持 HTTP 或 HTTPS |
+| `model` | string | `gpt-4o` | 模型名称 |
+| `omni_model` | bool | `false` | 是否直接使用多模态模型处理语音 |
+| `max_context_turns` | integer | `0` | 每个会话保留的最大对话轮数；`0` 表示禁用上下文 |
+| `max_context_sessions` | integer | `1000` | 最多保留的会话数；`0` 表示不限制 |
+| `max_concurrent_requests` | integer | `4` | 全局并发 LLM 请求上限，必须大于 `0` |
+
 ### NapCat 配置详解
 
 `[napcat]` 区段用于配置 QQ 机器人功能，通过 NapCat（OneBot 11 协议实现）连接 QQ。
@@ -52,7 +66,7 @@ sidebar_position: 3
 
 | 值 | 说明 |
 |---|---|---|
-| `ts3audiobot` | （默认）通过 TS 私信控制 TS3AudioBot，需确保音乐机器人昵称为 `TS3AudioBot` |
+| `ts3audiobot` | （配置示例）通过 TS 私信控制 TS3AudioBot，需确保音乐机器人昵称为 `TS3AudioBot` |
 | `tsmusicbot` | 通过 TS 私信控制 [TSMusicBot](https://github.com/ZHANGTIANYAO1/teamspeak-music-bot) |
 | `tsbot_backend` | 通过 HTTP API 控制 [NeteaseTSBot](https://github.com/yichen11818/NeteaseTSBot)，需设置 `base_url` |
 
@@ -84,9 +98,9 @@ sidebar_position: 3
 | `kick_client` | 踢出用户 |
 | `ban_client` | 封禁用户 |
 | `move_client` | 移动用户到指定频道 |
-| `get_client_list` | 获取在线用户列表 |
 | `get_client_info` | 获取用户详细信息 |
 | `music_control` | 音乐控制 |
+| `web_search` | 搜索最新网络信息 |
 
 ### NapCat 与跨平台行为说明
 

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -53,7 +53,7 @@ INFO Bot ready. Listening for TS + NapCat events.
 
 TeamSpeakClaw 支持三种音乐后端：
 
-**模式一：ts3audiobot（默认）**
+**模式一：ts3audiobot（配置示例）**
 
 通过 TS 私信控制 [TS3AudioBot](https://github.com/Splamy/TS3AudioBot)。需在 `settings.toml` 中配置 `musicbot_name`（默认 `TS3AudioBot`）。
 
@@ -123,8 +123,8 @@ TeamSpeakClaw 支持三种音乐后端：
 
 ### ℹ️ 信息查询
 
-- **查询在线用户** (get_client_list): "现在谁在线？"
 - **查询用户信息** (get_client_info): "UserA 的详细信息"
+- **搜索网络** (web_search): "搜索今天的最新新闻"
 
 ## 常见问题
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
@@ -16,6 +16,20 @@ Contains basic configurations for connecting to the TeamSpeak server, LLM provid
 
 **View full configuration example**: [settings.toml](https://github.com/Dr1mH4X/TeamSpeakClaw/blob/main/examples/config/settings.toml)
 
+### LLM Configuration
+
+The `[llm]` section configures an OpenAI-compatible Chat Completions endpoint:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | string | `""` | API key; may be empty for unauthenticated local services |
+| `base_url` | string | `https://api.openai.com/v1` | API base URL; only HTTP and HTTPS are supported |
+| `model` | string | `gpt-4o` | Model name |
+| `omni_model` | bool | `false` | Whether to process voice directly with a multimodal model |
+| `max_context_turns` | integer | `0` | Maximum conversation turns retained per session; `0` disables context |
+| `max_context_sessions` | integer | `1000` | Maximum retained sessions; `0` means unlimited |
+| `max_concurrent_requests` | integer | `4` | Global concurrent LLM request limit; must be greater than `0` |
+
 ### NapCat Configuration Details
 
 The `[napcat]` section configures the QQ bot functionality via NapCat (OneBot 11 protocol implementation).
@@ -52,7 +66,7 @@ The `[music_backend]` section controls which backend is used for music functiona
 
 | Value | Description |
 |---|---|---|
-| `ts3audiobot` | (Default) Controls TS3AudioBot via TS private messages. Ensure the music bot's nickname is `TS3AudioBot`. |
+| `ts3audiobot` | (Example configuration) Controls TS3AudioBot via TS private messages. Ensure the music bot's nickname is `TS3AudioBot`. |
 | `tsmusicbot` | Controls [TSMusicBot](https://github.com/ZHANGTIANYAO1/teamspeak-music-bot) via TS private messages. |
 | `tsbot_backend` | Controls [NeteaseTSBot](https://github.com/yichen11818/NeteaseTSBot) via HTTP API. Requires setting `base_url`. |
 
@@ -84,9 +98,9 @@ Controls which user groups can use which features. **All matching rules' allowed
 | `kick_client` | Kick a user |
 | `ban_client` | Ban a user |
 | `move_client` | Move a user to a specified channel |
-| `get_client_list` | Get online user list |
 | `get_client_info` | Get detailed user info |
 | `music_control` | Music control |
+| `web_search` | Search the web for current information |
 
 ### NapCat and Cross-platform Behavior Notes
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/usage.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/usage.md
@@ -53,7 +53,7 @@ The bot currently supports the following skills (depending on your permission co
 
 TeamSpeakClaw supports three music backends:
 
-**Mode 1: ts3audiobot (Default)**
+**Mode 1: ts3audiobot (Example configuration)**
 
 Controls [TS3AudioBot](https://github.com/Splamy/TS3AudioBot) via TS private messages. Set `musicbot_name` in `settings.toml` (default `TS3AudioBot`).
 
@@ -123,8 +123,8 @@ Controls [NeteaseTSBot](https://github.com/yichen11818/NeteaseTSBot) via HTTP AP
 
 ### ℹ️ Information Query
 
-- **List Online Users** (get_client_list): "Who is online right now?"
 - **Client Info** (get_client_info): "Show detailed info for UserA"
+- **Web Search** (web_search): "Search for today's latest news"
 
 ## FAQ
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -6,6 +6,11 @@ import Heading from "@theme/Heading";
 import styles from "./index.module.css";
 import Translate, { translate } from "@docusaurus/Translate";
 
+type FeatureItemProps = {
+  title: React.ReactNode;
+  description: React.ReactNode;
+};
+
 function HomepageHeader() {
   return (
     <header className={styles.heroBanner}>
@@ -97,7 +102,7 @@ export default function Home(): React.JSX.Element {
   );
 }
 
-function FeatureItem({ title, description }) {
+function FeatureItem({ title, description }: FeatureItemProps) {
   return (
     <div className="col col--3">
       <div className={styles.featureCard}>


### PR DESCRIPTION
## Summary

- harden TeamSpeak, voice, and NapCat routing with stable caller identity, real channel-group ACLs, managed task lifecycles, bounded audio concurrency, and reconnect fixes
- enforce skill permissions again at execution time and keep NapCat pseudo-groups consistent through target authorization
- make streamed LLM/tool handling fail closed for truncated responses, malformed calls, invalid finish reasons, excessive calls, and oversized arguments
- add shared LLM concurrency limits, atomic context eviction, configuration defaults and validation, checked numeric conversions, and stricter skill/backend input handling
- prevent LLM credentials, message bodies, WebSocket credentials, and upstream error bodies from leaking to third-party services or persistent logs
- align example configuration and bilingual documentation with the actual skill registry and defaults

## Why

The repository contained several cross-adapter inconsistencies and fail-open paths: schemas were ACL-filtered without execution-time revalidation, channel-group IDs were replaced with zero, unified skill failures could trigger duplicate side effects, voice work could outlive routers or be dropped under normal load, and incomplete streamed tool calls could still reach side-effecting executors. These changes make the three inbound paths use the same identity, authorization, ordering, and failure semantics.

## Impact

Callers now receive consistent authorization across text, STT, omni, and NapCat paths. Voice work is bounded and cancelled with the router, same-user requests remain ordered, tool execution has explicit limits, and configuration errors fail during startup. The new `max_concurrent_requests` setting defaults to `4`; existing configurations remain compatible.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` — 37 passed
- `cargo build --release --locked`
- `npm run typecheck`
- `npm run build` — zh-Hans and en
- `git diff --check`

## Known follow-up

- live TeamSpeak, NapCat, ffmpeg, STT, and TTS end-to-end environments were not available for integration testing
- the Docusaurus build dependency tree still reports npm audit findings; no forced or major-version dependency upgrade is included in this PR