### PR TITLE
feat(log): use custom local timestamp format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PROTOC=/usr/bin/protoc
 RUN cargo build --release
 
 FROM alpine:3.20
-RUN apk add --no-cache ca-certificates opus ffmpeg
+RUN apk add --no-cache ca-certificates opus ffmpeg tzdata
 RUN addgroup -g 1001 appgroup && \
     adduser -u 1001 -G appgroup -D -h /home/appuser -s /sbin/nologin appuser
 WORKDIR /app

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_slog::TracingSlogDrain;
 use tracing_subscriber::{
-    fmt::{self, time::LocalTime},
+    fmt::{self, format::Writer, time::FormatTime},
     layer::SubscriberExt,
     util::SubscriberInitExt,
     EnvFilter, Layer,
@@ -44,6 +44,14 @@ fn cleanup_old_logs(log_dir: &PathBuf, max_days: u32) {
     }
 }
 
+struct CustomTime;
+
+impl FormatTime for CustomTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        write!(w, "{}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S"))
+    }
+}
+
 pub fn init_tracing(console_level: &str, log_cfg: &LogConfig) -> WorkerGuard {
     let noise_directives = [
         "h2=off",
@@ -62,7 +70,7 @@ pub fn init_tracing(console_level: &str, log_cfg: &LogConfig) -> WorkerGuard {
     let console_layer = fmt::layer()
         .with_target(true)
         .compact()
-        .with_timer(LocalTime::rfc_3339())
+        .with_timer(CustomTime)
         .with_filter(console_filter);
 
     let log_dir: PathBuf = crate::config::exe_dir().join("logs");
@@ -82,7 +90,7 @@ pub fn init_tracing(console_level: &str, log_cfg: &LogConfig) -> WorkerGuard {
     let file_layer = fmt::layer()
         .with_writer(non_blocking)
         .with_ansi(false)
-        .with_timer(LocalTime::rfc_3339())
+        .with_timer(CustomTime)
         .with_filter(file_filter);
 
     tracing_subscriber::registry()

--- a/src/log.rs
+++ b/src/log.rs
@@ -44,11 +44,13 @@ fn cleanup_old_logs(log_dir: &PathBuf, max_days: u32) {
     }
 }
 
+const TIMESTAMP_FMT: &str = "%Y-%m-%d %H:%M:%S";
+
 struct CustomTime;
 
 impl FormatTime for CustomTime {
     fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
-        write!(w, "{}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S"))
+        write!(w, "{}", chrono::Local::now().format(TIMESTAMP_FMT))
     }
 }
 


### PR DESCRIPTION
- Add tzdata package to Docker image for timezone data
- Implement CustomTime formatter for local timestamps (YYYY-MM-DD HH:MM:SS)
- Replace RFC3339 timestamps with readable local time format in logs

## Summary by Sourcery

将日志时间戳更新为使用自定义本地时间格式，并确保运行时镜像中包含时区数据。

Enhancements:
- 引入自定义时间戳格式化器，以本地时间并采用更易读的格式记录时间戳。
- 将自定义时间戳格式化器应用于控制台和文件日志输出。

Build:
- 在运行时 Docker 镜像中包含 `tzdata` 包，为本地时间格式化提供时区数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update logging timestamps to use a custom local time format and ensure timezone data is available in the runtime image.

Enhancements:
- Introduce a custom timestamp formatter to log timestamps in local time using a human-readable format.
- Apply the custom timestamp formatter to both console and file logging outputs.

Build:
- Include the tzdata package in the runtime Docker image to provide timezone data for local time formatting.

</details>