### PR TITLE
fix(headless): split long text messages into UTF-8 safe chunks

### DIFF
--- a/src/adapter/headless.rs
+++ b/src/adapter/headless.rs
@@ -26,6 +26,7 @@ use voicev1::voice_service_server::VoiceServiceServer;
 mod actor;
 mod event;
 pub mod speech;
+pub(crate) mod text_util;
 mod types;
 mod voice_service;
 

--- a/src/adapter/headless/actor.rs
+++ b/src/adapter/headless/actor.rs
@@ -7,6 +7,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
+use super::text_util::split_message;
 use super::tsbot::voice::v1 as voicev1;
 use super::types::now_unix_ms;
 
@@ -105,13 +106,15 @@ pub async fn ts3_actor(
                 if let Some((mode, target, text)) = msg {
                     let target_mode = if mode == 1 || mode == 2 || mode == 3 { mode } else { 2 };
                     let target = if target_mode == 1 { target } else { 0 };
-                    if let Err(e) = tsclient_rs::sendTextMessage(
-                        &client,
-                        target_mode,
-                        target as u64,
-                        &text,
-                    ).await {
-                        warn!("sendTextMessage failed: {e}");
+                    for chunk in split_message(&text, 8192) {
+                        if let Err(e) = tsclient_rs::sendTextMessage(
+                            &client,
+                            target_mode,
+                            target as u64,
+                            &chunk,
+                        ).await {
+                            warn!("sendTextMessage failed: {e}");
+                        }
                     }
                 } else {
                     break;

--- a/src/adapter/headless/actor.rs
+++ b/src/adapter/headless/actor.rs
@@ -106,7 +106,7 @@ pub async fn ts3_actor(
                 if let Some((mode, target, text)) = msg {
                     let target_mode = if mode == 1 || mode == 2 || mode == 3 { mode } else { 2 };
                     let target = if target_mode == 1 { target } else { 0 };
-                    for chunk in split_message(&text, 8192) {
+                    for chunk in split_message(&text, super::text_util::MAX_MESSAGE_BYTES) {
                         if let Err(e) = tsclient_rs::sendTextMessage(
                             &client,
                             target_mode,

--- a/src/adapter/headless/event.rs
+++ b/src/adapter/headless/event.rs
@@ -221,7 +221,7 @@ impl TsAdapter {
     }
 
     pub async fn send_text_message(&self, target_mode: u8, target: u32, msg: &str) -> Result<()> {
-        for chunk in super::text_util::split_message(msg, 8192) {
+        for chunk in super::text_util::split_message(msg, super::text_util::MAX_MESSAGE_BYTES) {
             tsclient_rs::sendTextMessage(&self.client, target_mode as i32, target as u64, &chunk)
                 .await
                 .map_err(|e| anyhow!("sendTextMessage failed: {e}"))?;

--- a/src/adapter/headless/event.rs
+++ b/src/adapter/headless/event.rs
@@ -221,9 +221,12 @@ impl TsAdapter {
     }
 
     pub async fn send_text_message(&self, target_mode: u8, target: u32, msg: &str) -> Result<()> {
-        tsclient_rs::sendTextMessage(&self.client, target_mode as i32, target as u64, msg)
-            .await
-            .map_err(|e| anyhow!("sendTextMessage failed: {e}"))
+        for chunk in super::text_util::split_message(msg, 8192) {
+            tsclient_rs::sendTextMessage(&self.client, target_mode as i32, target as u64, &chunk)
+                .await
+                .map_err(|e| anyhow!("sendTextMessage failed: {e}"))?;
+        }
+        Ok(())
     }
 
     pub async fn poke(&self, clid: u32, msg: &str) -> Result<()> {

--- a/src/adapter/headless/text_util.rs
+++ b/src/adapter/headless/text_util.rs
@@ -1,8 +1,13 @@
-/// 按 UTF-8 字节长度分片，每片不超过 max_bytes。
-/// 优先在空白符处分片，回退到字符边界处截断（绝不断开多字节字符）。
-/// 注意：空白符被丢弃在分片边界，不影响语义。
+/// TeamSpeak ServerQuery 单行消息最大字节数限制。
+pub const MAX_MESSAGE_BYTES: usize = 8192;
+
+/// 按 UTF-8 字节长度分片，每片不超过 `max_bytes`。
+/// 若单个字符超过 `max_bytes`，该字符独自成片（不截断字符）。
+/// 优先在空白符处分片，回退到字符边界截断。
+/// 注意：分片边界上的空白符被丢弃，不影响语义。
 pub fn split_message(msg: &str, max_bytes: usize) -> Vec<String> {
-    if msg.len() <= max_bytes || max_bytes == 0 {
+    debug_assert!(max_bytes > 0, "max_bytes must be > 0");
+    if msg.len() <= max_bytes {
         return vec![msg.to_string()];
     }
 
@@ -40,7 +45,9 @@ pub fn split_message(msg: &str, max_bytes: usize) -> Vec<String> {
                 let ws = lookback_start + rel_pos;
                 if ws > start {
                     chunks.push(msg[start..ws].to_string());
-                    start = ws + 1; // 跳过空白符
+                    // 跳过完整空白符（可能多字节，如全角空格）
+                    let ws_chars: Vec<char> = msg[ws..].chars().collect();
+                    start = ws + ws_chars[0].len_utf8();
                     continue;
                 }
             }

--- a/src/adapter/headless/text_util.rs
+++ b/src/adapter/headless/text_util.rs
@@ -1,0 +1,59 @@
+/// 按 UTF-8 字节长度分片，每片不超过 max_bytes。
+/// 优先在空白符处分片，回退到字符边界处截断（绝不断开多字节字符）。
+/// 注意：空白符被丢弃在分片边界，不影响语义。
+pub fn split_message(msg: &str, max_bytes: usize) -> Vec<String> {
+    if msg.len() <= max_bytes || max_bytes == 0 {
+        return vec![msg.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let len = msg.len();
+
+    while start < len {
+        let mut end = (start + max_bytes).min(len);
+
+        if end == len {
+            chunks.push(msg[start..].to_string());
+            break;
+        }
+
+        // 回退到字符边界
+        while !msg.is_char_boundary(end) {
+            end -= 1;
+        }
+
+        // 若一个字符就超过 max_bytes，强制包含整个字符（不截断）
+        if end == start {
+            end = start + 1;
+            while !msg.is_char_boundary(end) {
+                end += 1;
+            }
+        }
+
+        // 在 end 之前找最近的空白符（最多回看 256 字节）
+        let lookback_start = end.saturating_sub(256).max(start);
+        if lookback_start < end {
+            if let Some(rel_pos) = msg[lookback_start..end]
+                .rfind(|c: char| c.is_whitespace())
+            {
+                let ws = lookback_start + rel_pos;
+                if ws > start {
+                    chunks.push(msg[start..ws].to_string());
+                    start = ws + 1; // 跳过空白符
+                    continue;
+                }
+            }
+        }
+
+        // 没有合适的空白符，直接按字符边界截断
+        chunks.push(msg[start..end].to_string());
+        start = end;
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+include!("../../test/text_util.rs");
+

--- a/src/test/text_util.rs
+++ b/src/test/text_util.rs
@@ -44,11 +44,6 @@ fn emoji_preserved() {
 }
 
 #[test]
-fn max_bytes_zero_returns_whole() {
-    assert_eq!(split_message("test", 0), vec!["test"]);
-}
-
-#[test]
 fn whitespace_break_preferred() {
     let r: Vec<String> = split_message("hello world foo bar", 10);
     assert!(r.iter().all(|c: &String| c.len() <= 10));
@@ -75,6 +70,15 @@ fn long_text_roundtrip() {
     let r: Vec<String> = split_message(&msg, 8192);
     assert!(r.iter().all(|c: &String| c.len() <= 8192));
     assert_eq!(r.join(""), msg);
+}
+
+#[test]
+fn fullwidth_space_not_corrupt() {
+    // 全角空格 U+3000 = 3 字节，旧 bug：start = ws + 1 会落在中间
+    let msg = "a\u{3000}b\u{3000}c";
+    let r: Vec<String> = split_message(msg, 3);
+    assert!(r.iter().all(|c: &String| !c.is_empty()));
+    assert_eq!(r.concat(), msg);
 }
 
 #[test]

--- a/src/test/text_util.rs
+++ b/src/test/text_util.rs
@@ -1,0 +1,86 @@
+// 此文件通过 include! 编译到 adapter::headless::text_util 模块中，
+// 可直接访问 split_message 等模块内函数。
+
+#[test]
+fn short_message_single_chunk() {
+    let result = split_message("hello", 8192);
+    assert_eq!(result, vec!["hello"]);
+}
+
+#[test]
+fn exact_fit() {
+    let r = split_message("abcde", 5);
+    assert_eq!(r, vec!["abcde"]);
+}
+
+#[test]
+fn ascii_split_preserves_all_chars() {
+    let msg = "hello world foo bar";
+    let r = split_message(msg, 8);
+    for (i, c) in r.iter().enumerate() {
+        assert!(c.len() <= 8, "chunk {i} len {} > 8", c.len());
+    }
+    let joined: String = r.concat();
+    let without_ws: String = joined.chars().filter(|c: &char| !c.is_whitespace()).collect();
+    let expected: String = msg.chars().filter(|c: &char| !c.is_whitespace()).collect();
+    assert_eq!(without_ws, expected);
+}
+
+#[test]
+fn chinese_no_break() {
+    let msg = "你好世界这是一个测试消息";
+    let r = split_message(msg, 9);
+    assert!(r.iter().all(|c: &String| c.len() <= 9), "chunks: {r:?}");
+}
+
+#[test]
+fn emoji_preserved() {
+    let msg = "a🥴bc";
+    let r = split_message(msg, 2);
+    assert_eq!(r.len(), 3);
+    assert_eq!(r[0], "a");
+    assert_eq!(r[1], "🥴");
+    assert_eq!(r[2], "bc");
+}
+
+#[test]
+fn max_bytes_zero_returns_whole() {
+    assert_eq!(split_message("test", 0), vec!["test"]);
+}
+
+#[test]
+fn whitespace_break_preferred() {
+    let r: Vec<String> = split_message("hello world foo bar", 10);
+    assert!(r.iter().all(|c: &String| c.len() <= 10));
+    let joined: String = r.concat();
+    let without_ws: String = joined.chars().filter(|c: &char| !c.is_whitespace()).collect();
+    let expected: String = "hello world foo bar".chars().filter(|c: &char| !c.is_whitespace()).collect();
+    assert_eq!(without_ws, expected);
+}
+
+#[test]
+fn mixed_content() {
+    let msg = "hello 你好 world 🥴 test";
+    let r: Vec<String> = split_message(msg, 10);
+    assert!(r.iter().all(|c: &String| c.len() <= 10), "chunks: {r:?}");
+    let joined: String = r.concat();
+    let without_ws: String = joined.chars().filter(|c: &char| !c.is_whitespace()).collect();
+    let expected: String = msg.chars().filter(|c: &char| !c.is_whitespace()).collect();
+    assert_eq!(without_ws, expected);
+}
+
+#[test]
+fn long_text_roundtrip() {
+    let msg = "a".repeat(10000);
+    let r: Vec<String> = split_message(&msg, 8192);
+    assert!(r.iter().all(|c: &String| c.len() <= 8192));
+    assert_eq!(r.join(""), msg);
+}
+
+#[test]
+fn all_emoji() {
+    let msg = "🥴🥴🥴🥴";
+    let r: Vec<String> = split_message(msg, 6);
+    assert!(r.iter().all(|c: &String| c.len() <= 6));
+    assert_eq!(r.join(""), msg);
+}


### PR DESCRIPTION
Split messages exceeding 8192 bytes at whitespace boundaries while preserving UTF-8 character integrity. Applied to both actor and event message sending paths.

## Summary by Sourcery

在通过无界面适配器发送消息时，将外发文本消息拆分为 UTF-8 安全的片段，以避免负载过大。

Bug 修复：
- 当消息大小超过 8192 字节时，通过将其拆分为更小的片段，防止 `sendTextMessage` 调用失败。

增强功能：
- 引入可复用的 `text_util::split_message` 辅助函数，用于在保持 UTF-8 字符边界和语义的前提下，在空白处拆分消息。

测试：
- 为 `split_message` 添加完整的单元测试，覆盖 ASCII、CJK（中日韩字符）、表情符号、倾向按空白拆分以及长文本往返场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split outgoing text messages into UTF-8–safe chunks when sending via the headless adapter to avoid oversized payloads.

Bug Fixes:
- Prevent sendTextMessage calls from failing by splitting messages that exceed 8192 bytes into smaller chunks.

Enhancements:
- Introduce a reusable text_util::split_message helper to split messages at whitespace while preserving UTF-8 character boundaries and semantics.

Tests:
- Add comprehensive unit tests for split_message covering ASCII, CJK, emojis, whitespace-preferred splitting, and long-text round trips.

</details>