### PR TITLE
refactor(adapter/headless): simplify client name tracking with one-time

### DIFF
--- a/src/adapter/headless/actor.rs
+++ b/src/adapter/headless/actor.rs
@@ -1,9 +1,8 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use dashmap::DashMap;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -25,52 +24,8 @@ pub async fn ts3_actor(
     let mut out_buf: VecDeque<(Vec<u8>, i32)> = VecDeque::with_capacity(400);
 
     let mut send_tick = tokio::time::interval(Duration::from_millis(20));
-    let client_names = Arc::new(DashMap::<i32, String>::new());
 
-    let enter_names = client_names.clone();
-    client.on_client_enter(Arc::new(move |event: tsclient_rs::Event| {
-        if let tsclient_rs::Event::ClientEnter(client) = event {
-            enter_names.insert(client.id, client.nickname);
-        }
-    }));
-
-    let leave_names = client_names.clone();
-    client.on_client_leave(Arc::new(move |event: tsclient_rs::Event| {
-        if let tsclient_rs::Event::ClientLeave(client) = event {
-            leave_names.remove(&client.id);
-        }
-    }));
-
-    // voice data → AudioFrameEvent
-    let events_tx_v = events_tx.clone();
-    let voice_names = client_names.clone();
-    client.on_voice_data(Arc::new(move |event: tsclient_rs::Event| {
-        if let tsclient_rs::Event::VoiceData(ref vd) = event {
-            let Ok(from_client_id) = u32::try_from(vd.client_id) else {
-                warn!(
-                    client_id = vd.client_id,
-                    "忽略调用者 ID 无效的 TeamSpeak 音频帧"
-                );
-                return;
-            };
-            let from_client_name = voice_names
-                .get(&vd.client_id)
-                .map(|name| name.clone())
-                .unwrap_or_default();
-            let _ = events_tx_v.send(voicev1::Event {
-                unix_ms: now_unix_ms(),
-                payload: Some(voicev1::event::Payload::Audio(voicev1::AudioFrameEvent {
-                    from_client_id,
-                    from_client_name,
-                    codec: vd.codec,
-                    is_whisper: false,
-                    frame: vd.data.to_vec(),
-                })),
-            });
-        }
-    }));
-
-    // text message → ChatEvent (for TTS via voice_router)
+    // 先注册 text handler，避免丢消息
     let events_tx_t = events_tx.clone();
     let respond_private = bot_respond_to_private;
     let reply_mode = bot_default_reply_mode.clone();
@@ -123,14 +78,45 @@ pub async fn ts3_actor(
         }
     }));
 
-    match tsclient_rs::listClients(&client).await {
-        Ok(clients) => {
-            for client in clients {
-                client_names.insert(client.id, client.nickname);
+    // 启动时 listClients 一次，填充 name 映射供 voice handler 使用
+    let client_names: Arc<HashMap<i32, String>> = Arc::new(
+        match tsclient_rs::listClients(&client).await {
+            Ok(clients) => clients.into_iter().map(|c| (c.id, c.nickname)).collect(),
+            Err(e) => {
+                warn!("初始化 TeamSpeak 客户端名称失败: {e}");
+                HashMap::new()
             }
+        },
+    );
+
+    // voice data → AudioFrameEvent
+    let events_tx_v = events_tx.clone();
+    let voice_names = client_names;
+    client.on_voice_data(Arc::new(move |event: tsclient_rs::Event| {
+        if let tsclient_rs::Event::VoiceData(ref vd) = event {
+            let Ok(from_client_id) = u32::try_from(vd.client_id) else {
+                warn!(
+                    client_id = vd.client_id,
+                    "忽略调用者 ID 无效的 TeamSpeak 音频帧"
+                );
+                return;
+            };
+            let from_client_name = voice_names
+                .get(&vd.client_id)
+                .cloned()
+                .unwrap_or_default();
+            let _ = events_tx_v.send(voicev1::Event {
+                unix_ms: now_unix_ms(),
+                payload: Some(voicev1::event::Payload::Audio(voicev1::AudioFrameEvent {
+                    from_client_id,
+                    from_client_name,
+                    codec: vd.codec,
+                    is_whisper: false,
+                    frame: vd.data.to_vec(),
+                })),
+            });
         }
-        Err(e) => warn!("初始化 TeamSpeak 客户端名称缓存失败: {e}"),
-    }
+    }));
 
     loop {
         tokio::select! {


### PR DESCRIPTION
listClients

Replace dynamic DashMap with static HashMap populated at startup via listClients.
Remove client enter/leave handlers that updated names in real-time. Voice handler
now uses the immutable snapshot. Text handler registered first to avoid message loss.

## Summary by Sourcery

通过使用一次性获取的客户端快照并调整事件处理器的注册顺序，简化 TeamSpeak 无界面适配器的客户端名称处理。

增强内容：
- 使用在启动时通过 `listClients` 一次性填充的静态 `HashMap`，替换基于动态 `DashMap` 的客户端名称缓存。
- 在语音数据处理器中使用不可变的客户端名称快照，而不是实时更新名称。
- 在其他处理器之前注册文本消息处理器，以确保启动期间不会丢失消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify TeamSpeak headless adapter client name handling by using a one-time snapshot of clients and adjusting event handler registration order.

Enhancements:
- Replace the dynamic DashMap-based client name cache with a static HashMap populated once at startup via listClients.
- Use the immutable client name snapshot in the voice data handler instead of updating names in real time.
- Register the text message handler before other handlers to ensure messages are not lost during startup.

</details>