### PR TITLE
refactor(router): unify chat LLM triggers and strip prefixes

### DIFF
--- a/src/adapter/headless/actor.rs
+++ b/src/adapter/headless/actor.rs
@@ -45,11 +45,15 @@ pub async fn ts3_actor(
                 );
                 return;
             };
-            let msg_content = msg.message.trim().to_string();
-            let should_trigger_llm = (target_mode == 1 && respond_private)
-                || bot_trigger_prefixes
-                    .iter()
-                    .any(|prefix| msg_content.starts_with(prefix));
+            let raw_content = msg.message.trim().to_string();
+            let (msg_content, should_trigger_llm) = if target_mode == 1 && respond_private {
+                (raw_content, true)
+            } else {
+                match bot_trigger_prefixes.iter().find(|p| raw_content.starts_with(p.as_str())) {
+                    Some(prefix) => (raw_content[prefix.len()..].trim().to_string(), true),
+                    None => (raw_content, false),
+                }
+            };
             let (reply_target_mode, reply_target_client_id) = if target_mode == 1 {
                 (1, invoker_client_id)
             } else {

--- a/src/adapter/headless/actor.rs
+++ b/src/adapter/headless/actor.rs
@@ -49,8 +49,8 @@ pub async fn ts3_actor(
             let (msg_content, should_trigger_llm) = if target_mode == 1 && respond_private {
                 (raw_content, true)
             } else {
-                match bot_trigger_prefixes.iter().find(|p| raw_content.starts_with(p.as_str())) {
-                    Some(prefix) => (raw_content[prefix.len()..].trim().to_string(), true),
+                match crate::router::strip_trigger_prefix(&raw_content, &bot_trigger_prefixes) {
+                    Some(stripped) => (stripped.to_string(), true),
                     None => (raw_content, false),
                 }
             };

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,11 @@
 mod nc_router;
+mod trigger;
 mod ts_router;
 mod unified;
 mod voice_router;
 
 pub use nc_router::NcRouter;
+pub use trigger::strip_trigger_prefix;
 pub use ts_router::EventRouter;
 pub use unified::{ReplyPolicy, UnifiedInboundEvent};
 pub use voice_router::VoiceRouter;

--- a/src/router/nc_router.rs
+++ b/src/router/nc_router.rs
@@ -410,7 +410,7 @@ impl NcRouter {
                             json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id})
                         })
                         .collect();
-                    info!("Fetched {} online clients for LLM context", clients.len());
+                    debug!("Fetched {} online clients for LLM context", clients.len());
                     format!(
                         "\nOnline: {}",
                         serde_json::to_string(&arr).unwrap_or_default()

--- a/src/router/nc_router.rs
+++ b/src/router/nc_router.rs
@@ -10,7 +10,7 @@ use crate::config::{AppConfig, NapCatConfig, PromptsConfig};
 use crate::llm::context::SessionSource;
 use crate::llm::{LlmEngine, ToolCall, ToolExecutor};
 use crate::permission::PermissionGate;
-use crate::router::{ReplyPolicy, UnifiedInboundEvent};
+use crate::router::{ReplyPolicy, UnifiedInboundEvent, strip_trigger_prefix};
 use crate::skills::{is_skill_allowed, NcExecutionContext, SkillRegistry, UnifiedExecutionContext};
 use anyhow::Result;
 use serde_json::json;
@@ -322,13 +322,7 @@ impl NcRouter {
     }
 
     fn strip_prefix<'a>(&self, text: &'a str) -> &'a str {
-        let nc = &self.config.napcat;
-        for p in &nc.trigger_prefixes {
-            if let Some(rest) = text.strip_prefix(p.as_str()) {
-                return rest.trim();
-            }
-        }
-        text
+        strip_trigger_prefix(text, &self.config.napcat.trigger_prefixes).unwrap_or(text)
     }
 
     /// 执行单个工具调用，返回结果字符串

--- a/src/router/trigger.rs
+++ b/src/router/trigger.rs
@@ -1,5 +1,5 @@
-/// 按 config 中前缀列表逐个匹配并移除首个匹配的触发前缀，
-/// 返回去除前缀并 trim 后的文本。无匹配时返回 None。
+/// Match and strip the first matching trigger prefix from text.
+/// Returns the remainder after the prefix, trimmed. Returns None if no prefix matches.
 pub fn strip_trigger_prefix<'a>(text: &'a str, prefixes: &[String]) -> Option<&'a str> {
     for p in prefixes {
         if let Some(rest) = text.strip_prefix(p.as_str()) {

--- a/src/router/trigger.rs
+++ b/src/router/trigger.rs
@@ -1,0 +1,10 @@
+/// 按 config 中前缀列表逐个匹配并移除首个匹配的触发前缀，
+/// 返回去除前缀并 trim 后的文本。无匹配时返回 None。
+pub fn strip_trigger_prefix<'a>(text: &'a str, prefixes: &[String]) -> Option<&'a str> {
+    for p in prefixes {
+        if let Some(rest) = text.strip_prefix(p.as_str()) {
+            return Some(rest.trim());
+        }
+    }
+    None
+}

--- a/src/router/ts_router.rs
+++ b/src/router/ts_router.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 struct SqExecutor<'a> {
     router: &'a EventRouter,
@@ -199,7 +199,7 @@ impl EventRouter {
                     .find(|c| c.id as u32 == event.invoker_id)
                     .map(|c| c.channel_id)
                     .unwrap_or(0);
-                info!("Fetched {} online clients for LLM context", clients.len());
+                debug!("Fetched {} online clients for LLM context", clients.len());
                 (
                     serde_json::to_string(&arr).unwrap_or_default(),
                     invoker_chan,

--- a/src/router/unified.rs
+++ b/src/router/unified.rs
@@ -45,12 +45,15 @@ impl UnifiedInboundEvent {
         }
 
         let is_private = event.target_mode == TextMessageTarget::Private;
-        let should_trigger_llm = is_private && config.bot.respond_to_private
-            || config
-                .bot
-                .trigger_prefixes
-                .iter()
-                .any(|prefix| msg_content.starts_with(prefix));
+
+        let (text, should_trigger_llm) = if is_private && config.bot.respond_to_private {
+            (msg_content.to_string(), true)
+        } else {
+            match config.bot.trigger_prefixes.iter().find(|p| msg_content.starts_with(p.as_str())) {
+                Some(prefix) => (msg_content[prefix.len()..].trim().to_string(), true),
+                None => (msg_content.to_string(), false),
+            }
+        };
 
         let reply_policy = if is_private {
             ReplyPolicy::TeamSpeak {
@@ -78,7 +81,7 @@ impl UnifiedInboundEvent {
             source: InboundSource::TeamSpeakText,
             sender_id: event.invoker_id.to_string(),
             sender_name: event.invoker_name.clone(),
-            text: msg_content.to_string(),
+            text,
             should_trigger_llm,
             should_respond: should_trigger_llm,
             reply_policy,

--- a/src/router/unified.rs
+++ b/src/router/unified.rs
@@ -2,6 +2,7 @@ use crate::adapter::napcat::event::{GroupMessageEvent, PrivateMessageEvent};
 use crate::adapter::napcat::types::segments_to_text;
 use crate::adapter::{TextMessageEvent, TextMessageTarget};
 use crate::config::AppConfig;
+use crate::router::strip_trigger_prefix;
 
 #[derive(Debug, Clone)]
 pub enum InboundSource {
@@ -49,8 +50,8 @@ impl UnifiedInboundEvent {
         let (text, should_trigger_llm) = if is_private && config.bot.respond_to_private {
             (msg_content.to_string(), true)
         } else {
-            match config.bot.trigger_prefixes.iter().find(|p| msg_content.starts_with(p.as_str())) {
-                Some(prefix) => (msg_content[prefix.len()..].trim().to_string(), true),
+            match strip_trigger_prefix(msg_content, &config.bot.trigger_prefixes) {
+                Some(stripped) => (stripped.to_string(), true),
                 None => (msg_content.to_string(), false),
             }
         };

--- a/src/router/voice_router.rs
+++ b/src/router/voice_router.rs
@@ -411,8 +411,11 @@ impl VoiceRouter {
         client: &mut VoiceServiceClient<Channel>,
         chat: voicev1::ChatEvent,
     ) -> Result<()> {
+        if !chat.should_trigger_llm {
+            return Ok(());
+        }
         let ctx = self.resolve_caller_from_chat(&chat).await?;
-        if self.should_ignore_chat(&chat, ctx.caller_id) || !chat.should_trigger_llm {
+        if self.should_ignore_chat(&chat, ctx.caller_id) {
             return Ok(());
         }
         let Some(clean_text) = preprocess_text_message(&chat.message) else {
@@ -723,7 +726,7 @@ impl VoiceRouter {
                     .iter()
                     .map(|c| json!({"name": c.nickname, "clid": c.id, "channel_id": c.channel_id}))
                     .collect();
-                info!("Fetched {} online clients for LLM context", clients.len());
+                debug!("Fetched {} online clients for LLM context", clients.len());
                 serde_json::to_string(&arr).unwrap_or_default()
             }
             Err(e) => {

--- a/src/skills/communication.rs
+++ b/src/skills/communication.rs
@@ -150,7 +150,7 @@ impl Skill for SendMessage {
 
         Ok(json!({
             "status": "ok",
-            "message": format!("Message sent successfully in {} mode", mode)
+            "message": format!("Message sent in {} mode: {}", mode, msg)
         }))
     }
 
@@ -273,7 +273,7 @@ impl Skill for SendMessage {
                             nc_adapter.send_private(target, &segs).await?;
                             Ok(json!({
                                 "status": "ok",
-                                "message": "Private message sent",
+                                "message": format!("Private message sent: {}", msg),
                                 "platform": "napcat",
                                 "routed_by": "default"
                             }))
@@ -288,7 +288,7 @@ impl Skill for SendMessage {
                             nc_adapter.send_group(group_id, &segs).await?;
                             Ok(json!({
                                 "status": "ok",
-                                "message": "Group message sent",
+                                "message": format!("Group message sent: {}", msg),
                                 "platform": "napcat",
                                 "routed_by": "default"
                             }))


### PR DESCRIPTION
## Sourcery 总结

针对通过聊天触发的 LLM 交互，在 TeamSpeak、语音和 Napcat 适配器中调整消息路由和日志行为。

新功能：
- 在将文本传递给 LLM 处理之前，从传入的聊天消息中剥离已配置的触发前缀；当未使用触发前缀时，保留原始内容不变。

改进：
- 在统一适配器和无界面适配器中统一 `should_trigger_llm` 的处理逻辑，仅在私聊消息或存在触发前缀时才触发。
- 当 `should_trigger_llm` 为 false 时，直接短路语音聊天处理以避免不必要的处理开销。
- 将 TeamSpeak、语音和 Napcat 路由器中与 “online-clients-for-LLM-context” 相关的日志级别从 info 降为 debug，以减少日志噪音。
- 在 SendMessage 技能的成功响应中返回实际发送的消息内容，适用于通用、私聊和群聊消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust message routing and logging behavior for chat-triggered LLM interactions across TeamSpeak, voice, and Napcat adapters.

New Features:
- Strip configured trigger prefixes from incoming chat messages before passing text to LLM handling while preserving original content when no trigger is used.

Enhancements:
- Align should_trigger_llm handling across unified and headless adapters to only trigger on private messages or when a trigger prefix is present.
- Short-circuit voice chat handling when should_trigger_llm is false to avoid unnecessary processing.
- Downgrade online-clients-for-LLM-context logs from info to debug in TeamSpeak, voice, and Napcat routers to reduce log noise.
- Include the actual sent message content in SendMessage skill success responses for generic, private, and group messages.

</details>